### PR TITLE
fix: hide gatsby tool until logo is fixed

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -51,11 +51,11 @@ const tools = [
     image: 'gridsome_webmo_logo.svg',
     link: 'https://github.com/Sergix/gridsome-plugin-monetization'
   },
-  {
-    name: 'Gatsby + Webmonetization',
-    image: 'gatsby_logo.svg',
-    link: 'https://github.com/mrmuhammadali/gatsby-plugin-monetization'
-  }
+  // {
+  //   name: 'Gatsby + Webmonetization',
+  //   image: 'gatsby_logo.svg',
+  //   link: 'https://github.com/mrmuhammadali/gatsby-plugin-monetization'
+  // }
 ]
 
 const siteConfig = {


### PR DESCRIPTION
Removed link to plugin by @mrmuhammadali as the logo is expanding beyond the borders of the button.