### PR TITLE
Update en.json

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -3,7 +3,7 @@
   "localized-strings": {
     "next": "Next",
     "previous": "Previous",
-    "tagline": "A JavaScript browser API which allows the creation of a payment stream from the user agent to the website",
+    "tagline": "A JavaScript browser API that allows the creation of a payment stream from the user agent to the website",
     "docs": {
       "api": {
         "title": "JavaScript API",


### PR DESCRIPTION
`that` instead of `which` sounds grammatically correct in the sentence. Suggested by my English teacher `Grammarly` as well.