### PR TITLE
Fix event typo

### DIFF
--- a/static/specification.html
+++ b/static/specification.html
@@ -454,7 +454,7 @@
           <dt><dfn>onprogress</dfn> attribute</dt>
           <dd>
             A {{ Monetization / onprogress }} attribute is an
-            {{ EventHandler }} for an {{ MonetizationStartEvent }} named
+            {{ EventHandler }} for an {{ MonetizationProgressEvent }} named
             "<a>progress</a>".
           </dd>
         </dl>


### PR DESCRIPTION
Other text in the spec indicates that progress is tied to the progress event, not the start event.