### PR TITLE
fix: only render stateful components once app is hydrated

### DIFF
--- a/src/page-support/prob-revshare/components/active-view.js
+++ b/src/page-support/prob-revshare/components/active-view.js
@@ -8,6 +8,7 @@ import { SharesMetaTag } from './meta-tag'
 import { SharesText } from './shares-text'
 import { ImportText } from './import-text'
 import { SectionHeader } from './section-header'
+import { OnlyClient } from './only-client'
 
 export function ActiveView () {
   const [ view ] = useView()
@@ -18,12 +19,14 @@ export function ActiveView () {
         Editing Revshare
       </SectionHeader>
       <SharesText />
-      <RevshareChart />
-      <ShareList />
-      <SectionHeader>
-        Meta Tag
-      </SectionHeader>
-      <SharesMetaTag />
+      <OnlyClient>
+        <RevshareChart />
+        <ShareList />
+        <SectionHeader>
+          Meta Tag
+        </SectionHeader>
+        <SharesMetaTag />
+      </OnlyClient>
     </>
   } else if (view === ViewStates.Import) {
     return <>

--- a/src/page-support/prob-revshare/components/only-client.js
+++ b/src/page-support/prob-revshare/components/only-client.js
@@ -1,0 +1,15 @@
+import React, { useState, useEffect } from 'react'
+
+export function OnlyClient ({ children }) {
+  const [ isClient, setClient ] = useState(false)
+
+  useEffect(() => {
+    setClient(true)
+  }, [])
+
+  if (isClient) {
+    return children
+  } else {
+    return <></>
+  }
+}


### PR DESCRIPTION
Fixes a server-side rendering bug that appeared on the live site, where a reload would trigger the server-side rendered page to not match the client-side rendered page due to the lack of localstorage. This change defers the loading of the chart and meta tag until it renders on the client-side, sidestepping this issue.

## Before
<img width="922" alt="Screen Shot 2020-09-25 at 3 47 17 PM" src="https://user-images.githubusercontent.com/3362563/94322111-6d041880-ff46-11ea-928e-96586b56c5d0.png">

## After
<img width="939" alt="Screen Shot 2020-09-25 at 3 46 27 PM" src="https://user-images.githubusercontent.com/3362563/94322108-6c6b8200-ff46-11ea-97f7-317caec59c7c.png">

