### PR TITLE
feat: use payment pointer instead of url form for revshare

### DIFF
--- a/src/page-support/prob-revshare/lib/index.js
+++ b/src/page-support/prob-revshare/lib/index.js
@@ -112,13 +112,18 @@ export function tagToShares (tag) {
   return pointerToShares(meta.content)
 }
 
+function isRevsharePointer (str) {
+  return str.startsWith(BASE_REVSHARE_POINTER)
+    || str.startsWith(normalizePointerPrefix(BASE_REVSHARE_POINTER))
+}
+
 export function tagOrPointerToShares (tag) {
   const trimmedTag = tag.trim()
   if (!trimmedTag) {
     throw new Error('Tag or pointer is empty')
   }
 
-  if (trimmedTag.startsWith(BASE_REVSHARE_POINTER)) {
+  if (isRevsharePointer(trimmedTag)) {
     return pointerToShares(trimmedTag)
   } else {
     return tagToShares(trimmedTag)

--- a/src/page-support/prob-revshare/lib/index.js
+++ b/src/page-support/prob-revshare/lib/index.js
@@ -1,4 +1,4 @@
-const BASE_REVSHARE_POINTER = 'https://webmonetization.org/api/revshare/pay/'
+const BASE_REVSHARE_POINTER = '$webmonetization.org/api/revshare/pay/'
 const POINTER_LIST_PARAM = 'p'
 const CHART_COLORS = [
   '#6ADAAB',
@@ -65,21 +65,17 @@ export function sharesToPaymentPointer (shares) {
 
   const pointerList = sharesToPointerList(validShares)
   const encodedShares = base64url(JSON.stringify(pointerList))
-
-  const params = new URLSearchParams()
-  params.set(POINTER_LIST_PARAM, encodedShares)
-
-  const parsedPointer = new URL(BASE_REVSHARE_POINTER)
-  parsedPointer.search = params.toString()
-
-  return parsedPointer.href
+  return BASE_REVSHARE_POINTER + encodedShares
 }
 
 export function pointerToShares (pointer) {
   try {
-    const parsed = new URL(pointer)
+    const parsed = new URL(normalizePointerPrefix(pointer))
     const params = new URLSearchParams(parsed.search)
+
+    // list could be in query string or in path segment
     const encodedList = params.get(POINTER_LIST_PARAM)
+      || parsed.pathname.split('/').pop()
 
     if (!encodedList) {
       throw new Error('No share data found. Make sure you copy the whole "content" field from your meta tag.')
@@ -157,6 +153,12 @@ export function validatePointerList (pointerList) {
   return true
 }
 
+export function normalizePointerPrefix (pointer) {
+  return pointer.startsWith('$')
+    ? 'https://' + pointer.substring(1)
+    : pointer
+}
+
 export function validatePointer (pointer) {
   if (!pointer) {
     return true
@@ -166,12 +168,8 @@ export function validatePointer (pointer) {
     return false
   }
 
-  const urlForm = pointer.startsWith('$')
-    ? 'https://' + pointer.substring(1)
-    : pointer
-
   try {
-    const _ = new URL(urlForm)
+    const _ = new URL(normalizePointerPrefix(pointer))
     return true
   } catch (e) {
     return false

--- a/workers/probabilistic-revshare/src/lib/pointers.ts
+++ b/workers/probabilistic-revshare/src/lib/pointers.ts
@@ -37,7 +37,10 @@ export function parsePointerMap (url: string): PointerList {
   const parsed = new URL(url)
   const search = new URLSearchParams(parsed.search)
 
+  // pointer list could be in final path segment or query param
   const pointerListB64 = search.get(POINTER_LIST_PARAM)
+    || parsed.pathname.split('/').pop()
+
   if (!pointerListB64) {
     throw new Error('request does not include pointer list')
   }


### PR DESCRIPTION
<img width="873" alt="Screen Shot 2020-09-30 at 1 53 20 PM" src="https://user-images.githubusercontent.com/3362563/94738736-b4165300-0324-11eb-9013-3d5b24934979.png">

Suggestion from Stefan, uses the payment pointer form in the meta tag instead of the url form (`http://webmonetization.org...`) to be clearer for users. As a consequence, the share data must be moved into the path instead of the query string, as query strings are forbidden in payment pointer form.