### PR TITLE
feat: pass on origin

### DIFF
--- a/workers/receipt-verifier/src/index.ts
+++ b/workers/receipt-verifier/src/index.ts
@@ -18,7 +18,8 @@ addEventListener('fetch', event => {
     body: event.request.body,
     headers: passHeaders(event.request.headers, [
       'accept',
-      'content-type'
+      'content-type',
+      'origin'
     ])
   }))
 })


### PR DESCRIPTION
passes the origin along to the receipt verifier so that it returns the CORS headers