### PR TITLE
doc: investigate broken links

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,11 +15,11 @@ how to pay you.
 4. Add the `<meta>` tag to each page of your website that you want to monetize.
 
 For a more detailed look at web monetizing your site, see the
-[Web Monetization explainer](./explainer#getting-started).
+[Web Monetization explainer](explainer.md#getting-started).
 
 ## 1. Set up a web monetized wallet
 
-Choose a [wallet that supports Web Monetization](./ilp-wallets) and set up an account.
+Choose a [wallet that supports Web Monetization](ilp-wallets.md) and set up an account.
 The wallet must support the Interledger Protocol (ILP).
 
 ## 2. Get your payment pointer

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -7,14 +7,14 @@ sidebar_label: Glossary
 # Monetized web page
 * * *
 A page on a monetized website that contains the necessary
-[`meta` tag](./explainer#add-lt-meta-gt-tag-to-website-header) defining the
+[`meta` tag](explainer#add-lt-meta-gt-tag-to-website-header.md) defining the
 page's receiving address (payment pointer).
 
 # Payment pointer
 * * *
 A secure URL that points to a payment initiation endpoint on the web. The
 payment pointer is provided by the Web Monetization receiver.
-See [Payment pointers](./explainer#payment-pointers) for more info.
+See [Payment pointers](explainer#payment-pointers.md) for more info.
 
 # Receiver
 * * *
@@ -29,7 +29,7 @@ The person with the sending wallet account. Also see
 # User agent
 * * *
 The user's web browser. In this context, the browser has implemented the
-[JavaScript API](./api.md) and has an installed/registered Web Monetization
+[JavaScript API](api.md) and has an installed/registered Web Monetization
 agent.
 
 The terms _user agent_ and _browser_ are used interchangeably throughout the
@@ -44,19 +44,19 @@ much to pay them.
 # Web Monetization provider
 * * *
 The digital entity (wallet) sending micropayments. Also referred to as the _Web
-Monetization sender_. See [Sending payments](./sending.md) for more
+Monetization sender_. See [Sending payments](sending.md) for more
 information.
 
 # Web Monetization receiver
 * * *
 The digital entity (wallet) receiving micropayments.
-See [Receiving payments](./receiving.md) and [ILP wallets](./ilp-wallets) for
+See [Receiving payments](receiving.md) and [ILP wallets](ilp-wallets.md) for
 more info.
 
 # Web Monetization session
 * * *
 Each page load or refresh is a unique session. The browser generates a
-[unique session ID](./explainer#flow) which the website can use to correlate
+[unique session ID](explainer.md#flow) which the website can use to correlate
 incoming payments to the Web Monetization receiver to a client-side context.
 
 # Receipt Verifier

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -7,14 +7,14 @@ sidebar_label: Glossary
 # Monetized web page
 * * *
 A page on a monetized website that contains the necessary
-[`meta` tag](explainer#add-lt-meta-gt-tag-to-website-header.md) defining the
+[`meta` tag](explainer.md#add-lt-meta-gt-tag-to-website-header) defining the
 page's receiving address (payment pointer).
 
 # Payment pointer
 * * *
 A secure URL that points to a payment initiation endpoint on the web. The
 payment pointer is provided by the Web Monetization receiver.
-See [Payment pointers](explainer#payment-pointers.md) for more info.
+See [Payment pointers](explainer.md#payment-pointers) for more info.
 
 # Receiver
 * * *


### PR DESCRIPTION
I'm finding that some links break for me, and when I go back from the error page, the link then works properly. I've updated two pages to try and solve the issue.