### PR TITLE
feat: use google cloudrun verifier to avoid worker to worker call 

### DIFF
--- a/workers/exclusive-content/src/lib/helpers.ts
+++ b/workers/exclusive-content/src/lib/helpers.ts
@@ -27,8 +27,8 @@ export function ab2str(ab: ArrayBuffer): string {
 
 export function str2ab(str: string): ArrayBuffer {
   const decodedString = atob(str)
-  var ab = new ArrayBuffer(decodedString.length)
-  var abView = new Uint8Array(ab)
+  const ab = new ArrayBuffer(decodedString.length)
+  const abView = new Uint8Array(ab)
   for (var i = 0, strLen = decodedString.length; i < strLen; i++) {
     abView[i] = decodedString.charCodeAt(i)
   }

--- a/workers/exclusive-content/src/lib/receiptVerifier.ts
+++ b/workers/exclusive-content/src/lib/receiptVerifier.ts
@@ -1,6 +1,15 @@
+const VERIFIER = 'https://receipt-verifier-dehz6dtlzq-uc.a.run.app'
+
 export async function verifyReceipt(verifier: string, receipt: string) {
+  const verifierUrl = verifier.startsWith(
+    'https://webmonetization.org/api/receipts',
+  )
+    ? VERIFIER
+    : verifier
   const endpoint = new URL(
-    verifier.endsWith('/') ? `${verifier}verify` : `${verifier}/verify`,
+    verifierUrl.endsWith('/')
+      ? `${verifierUrl}verify`
+      : `${verifierUrl}/verify`,
   )
   const response = await fetch(endpoint.href, { method: 'POST', body: receipt })
   return response.ok


### PR DESCRIPTION
Since a cloudflare worker cannot call another cloudflare worker, we change the verifier URL to the google cloudrun URL to talk to the verifier directly and not via the cloudflare worker. 

This needs to be deployed to cloudflare after merging. 