### PR TITLE
feat: add link to exclusive content generator to footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -152,7 +152,8 @@ const siteConfig = {
           items: [
             { label: 'Home', to: '/' },
             { label: 'Meta Tag Generator', to: '/meta-tag' },
-            { label: 'Revshare Generator', to: '/prob-revshare' }
+            { label: 'Revshare Generator', to: '/prob-revshare' },
+            { label: 'Exclusive Content Generator', to: '/exclusive-content' }
           ]
         },
         {


### PR DESCRIPTION
@justmoon suggested to also add the exclusive content generator to the footer where all the other generators are linked. 