### PR TITLE
Updates to support Open Payments

### DIFF
--- a/static/specification.html
+++ b/static/specification.html
@@ -59,10 +59,6 @@
             title: 'Interledger Protocol',
             href: 'https://interledger.org/rfcs/0027-interledger-protocol-4/',
           },
-          SPSP: {
-            title: 'Simple Payments Setup Protocol',
-            href: 'https://interledger.org/rfcs/0009-simple-payment-setup-protocol',
-          },
           STREAM: {
             title: 'STREAM',
             href: 'https://interledger.org/rfcs/0029-stream/',
@@ -73,7 +69,7 @@
           },
           'Open-Payments': {
             title: 'Open Payments',
-            href: 'https://docs.openpayments.dev/',
+            href: 'https://docs.openpayments.guide/',
           },
         },
       }
@@ -178,10 +174,11 @@
         </h3>
         <p>
           The {{MonetizationEvent}} DOM events provide information such as the
-          amount received, the currency of the payment (what we call the "asset
-          code"), and a receipt that can be used to verify the receipt of
-          payment. As in the previous example above, these events are
-          dispatched to [^link^] elements and bubble up the DOM tree.
+          amount sent, the currency of the payment (what we call the "asset
+          code"), and a link to the incoming payment at the [=monetization
+          receiver=] which can be used to verify the receipt of payment. As in
+          the previous example above, these events are dispatched to [^link^]
+          elements and bubble up the DOM tree.
         </p>
         <p>
           To listen for {{MonetizationEvent}} events, an [=event listener=]
@@ -194,13 +191,12 @@
             &lt;script&gt;
               const link = document.querySelector('link[rel="monetization"]');
               link.addEventListener("monetization", event =&gt; {
-                // See how much was received and in what currency
+                // See how much was sent and in what currency
                 const { amount, assetCode, assetScale } = event;
-                console.log(`Received ${assetCode}${amount} (${assetScale}).`);
+                console.log(`Browser sent ${assetCode}${amount / (10 * assetScale)}.`);
 
-                // Use the receipt to verify the payment using
-                // a verification service (see next example).
-                verifyReceipt(event);
+                // Use the incoming payment URL to verify the payment at the receiver.
+                verifyPayment(event);
               });
             &lt;/script&gt;
           </pre>
@@ -208,27 +204,36 @@
       </section>
       <section>
         <h3>
-          Verifying a receipt
+          Verifying a payment
         </h3>
         <p>
-          The {{MonetizationEvent}}'s {{MonetizationEvent/receipt}} attribute
-          is a unique string that can be used to verify the payment using a
-          payment verification service.
+          The {{MonetizationEvent}}'s {{MonetizationEvent/incomingPayment}}
+          attribute is a URL that can be used to verify the payment at the
+          [=monetization receiver=].
         </p>
         <p>
-          Below is a hypothetical verification service "verifier.example" that
-          performs verification via a `POST` HTTP request.
+          In most cases requests to the URL will need to be authenticated.
+          Below is a hypothetical verification endpoint that will make
+          authenticated requests to the receiver and return the results.
         </p>
         <aside class="example">
           <pre class="JS">
             /** @type {MonetizationEvent} event */
-            async function verifyReceipt(event) {
+            async function verifyPayment(event) {
+              // Legacy receivers don't support returning incoming payment URLs
+              if(!event.incomingPayment){
+                throw new Error('No incoming payment URL')
+              }
+
               const body = JSON.stringify({
-                receipt: event.receipt
+                incomingPayment: event.incomingPayment
               });
 
-              const response = await fetch('https://verifier.example/verify/', {
+              const response = await fetch('/verify', {
                 method: 'POST',
+                credentials: 'same-origin',
+                mode: 'same-origin',
+                cache: 'no-cache',
                 headers: {
                   'Content-Type': 'application/json'
                 },
@@ -236,9 +241,10 @@
               });
 
               if (response.ok) {
-                // The payment was verified
-              } else {
-                // The payment was not verified
+                // The incoming payment was fetched successfully
+                const { receivedAmount } = JSON.parse(response.json())
+                const { amount, assetCode, assetScale } = receivedAmount;
+                console.log(`Received ${assetCode}${amount / (10 * assetScale)}.`);
               }
             }
           </pre>
@@ -287,9 +293,8 @@
         <dd>
           The party making payments on behalf of the user. A monetization
           provider leverages the [[[Interledger]]] suite of protocols and
-          technologies (e.g., [[Open-Payments]] or [[SPSP]], both based on
-          [[STREAM]]) to provide a high-level way to pay a [=monetization
-          receiver=].
+          technologies (e.g., [[Open-Payments]] based on [[STREAM]]) to provide
+          a high-level way to pay a [=monetization receiver=].
         </dd>
         <dt>
           <dfn>Monetization receiver</dfn>:
@@ -302,22 +307,18 @@
           <dfn>Payment end-point</dfn>:
         </dt>
         <dd>
-          A [=URL=] to a <a data-cite="SPSP#specification">SPSP end-point</a>
-          (i.e., a JSON resource containing details that facilitate payment).
+          A [=URL=] to a <a data-cite="Open-Payments#specification">Open
+          Payments account end-point</a> (i.e., a JSON resource containing
+          details that facilitate payment to an account).
         </dd>
         <dt>
-          <dfn>Payment connection</dfn>
+          <dfn>Payment session</dfn>
         </dt>
         <dd>
-          An [[[Interledger]]] network connection for the purpose of
-          facilitating a payment that is either:
-          <ol>
-            <li>made over [[STREAM]] and setup via [[SPSP]],
-            </li>
-            <li>or made over [[HTTP]] and [[STREAM]] and setup via
-            [[Open-Payments]].
-            </li>
-          </ol>
+          An session between a [=monetization provider=] and [=monetization
+          receiver=] initiated by the creation of an incoming payment resource
+          at the [=monetization receiver=]. One or more payments can be sent by
+          the [=monetization provider=] in a single session.
         </dd>
       </dl>
     </section>
@@ -335,7 +336,7 @@
         <li>Developers have a way to associate payments with their users, in
         order to provide a range of experiences.
         </li>
-        <li>Users retains control of if, when, and how payments are made to the
+        <li>Users retain control of if, when, and how payments are made to the
         site. For example, micropayments of a predetermined monetary value
         could be "streamed" to the site over time. Alternatively, the user
         could make one or many discreet "one-off" payment(s) of any arbitrary
@@ -358,7 +359,7 @@
         <p>
           Although a single HTML document can have multiple [^link^] elements
           with the "monetization" link type, the user agent might restrict the
-          number of concurrent [=payment connections=] it can simultaneously
+          number of concurrent [=payment sessions=] it can simultaneously
           support. In such a case, an "error" event will be fired at the
           [^link^] element where a connection can't be established.
         </p>
@@ -378,8 +379,9 @@
       </p>
       <div>
         <p>
-          There is no default type for resources given by the <code data-x=
-          "rel-monetization">monetization</code> keyword.
+          The default type for resources given by the <code data-x=
+          "rel-monetization">monetization</code> keyword is
+          <code>application/json</code>.
         </p>
         <p>
           The appropriate times to <span data-x=
@@ -529,8 +531,9 @@
           <li>
             <p>
               Otherwise, if <var>response</var>'s <span data-x=
-              "Content-Type">Content-Type metadata</span> is not a <span>JSON
-              MIME type</span>, then set <var>success</var> to false.
+              "Content-Type">Content-Type metadata</span> is not a
+              <code>application/json</code>, then set <var>success</var> to
+              false.
             </p>
           </li>
           <li>Let |json| be the result of [=parse JSON bytes to an Infra
@@ -538,16 +541,13 @@
           </li>
           <li>If |json| is an exception, then set <var>success</var> to false.
           </li>
-          <li>If |success| is true, perform simple payment validation with
-          |json| as per [[SPSP]], and set |success| to be the result.
-          </li>
           <li>
             <p>
               If the user agent has exhausted the number of allowed [=payment
-              connections=], set |success| to false.
+              sessions=], set |success| to false.
             </p>
           </li>
-          <li>Otherwise, establish a new [=payment connection=].
+          <li>Otherwise, establish a new [=payment session=].
           </li>
           <li>[=Queue an element task=] on the [=networking task source=] given
           |element| and the following steps:
@@ -563,7 +563,7 @@
       </div>
       <p>
         If a "monetization" <code>link</code> <span>becomes browsing-context
-        disconnected</span>, a user agent MUST stop the [=payment connection=].
+        disconnected</span>, a user agent MUST stop the [=payment session=].
       </p>
     </section>
     <section>
@@ -581,18 +581,18 @@
         monetization event
       </h2>
       <p>
-        When the [=payment connection=] has fulfilled an ILP |packet| with a
+        When the [=payment session=] has sent an |outgoing payment| with a
         non-zero amount, perform the following steps:
       </p>
       <ol class="algorithm">
         <li>Let |target:HTMLLinkElement| be the {{HTMLLinkElement}} associated
-        with the [=payment connection=].
+        with the [=payment session=].
         </li>
         <li>If |target| is `null`, then return.
         </li>
         <li>Let |eventInitDict:MonetizationEventInit| be a
         {{MonetizationEventInit}} dictionary, whose members are initialized to
-        match |packet|'s details.
+        match |outgoing payment|'s details.
           <p class="issue">
             We probably need to canonicalize things like `assetCode` to
             uppercase. See {{PaymentCurrencyAmount/currency}} for how it's done
@@ -644,6 +644,7 @@
           readonly attribute octet assetScale;
           readonly attribute DOMString? receipt;
           readonly attribute USVString paymentPointer;
+          readonly attribute USVString? incomingPayment;
         };
 
         dictionary MonetizationEventInit : EventInit {
@@ -652,6 +653,7 @@
           required octet assetScale;
           required DOMString? receipt;
           required USVString paymentPointer;
+          required USVString? incomingPayment;
         };
       </pre>
       <section>
@@ -687,6 +689,16 @@
         <h2>
           <dfn>receipt</dfn> attribute
         </h2>
+        <div class="warning">
+          <p>
+            The [=receipt=] attribute is deprecated.
+          </p>
+          <p>
+            All [=monetization receivers=] should be migrating from generating
+            [[[Receipts]]] to supporting incoming payments via [[Open
+            Payments]].
+          </p>
+        </div>
         <p>
           `null` or a base64-encoded [[[Receipt]]] issued by the [=monetization
           receiver=] to the [=monetization provider=] as proof of the total
@@ -701,6 +713,15 @@
         <p>
           A [=URL=] representing a [=payment end-point=]. When getting, returns
           the value it was initialized with.
+        </p>
+      </section>
+      <section>
+        <h2>
+          <dfn>incomingPayment</dfn> attribute
+        </h2>
+        <p>
+          A [=URL=] representing an incoming payment at the [=monetization
+          receiver=]. When getting, returns the value it was initialized with.
         </p>
       </section>
     </section>
@@ -826,13 +847,12 @@
       <p>
         As [=payment end-points=] are generally provided as a service (e.g.,
         Uphold), a <abbr title="Cross Site Scripting">XSS</abbr> attack could
-        inject malicious [=payment end-points=] into a page that uses the
-        same service. To mitigate such an attack, it is RECOMMENDED that
-        developers:
+        inject malicious [=payment end-points=] into a page that uses the same
+        service. To mitigate such an attack, it is RECOMMENDED that developers:
       </p>
       <ul>
-        <li>host a [=payment end-point=] on their own servers and request
-        [[SPSP]] details from the provider on the server as needed.
+        <li>host a [=payment end-point=] on their own servers and proxy [[Open
+        Payments]] requests on the server as needed.
         </li>
         <li>Set the `monetization-src` CSP directive to restrict requests to
         origins they control and trust to host [=payment end-points=].
@@ -851,8 +871,8 @@
       </p>
       <p>
         Further, the user agent gets the payment information from the [=payment
-        end-point=] to establish the [=payment connection=]. This also ensures
-        the [=monetization provider=] doesn't have access to a user's browsing
+        end-point=] to establish the [=payment session=]. This also ensures the
+        [=monetization provider=] doesn't have access to a user's browsing
         history or to the [=payment end-point=].
       </p>
     </section>


### PR DESCRIPTION
Removed references to SPSP
Deprecated the receipt attribute of monetization event

The major change here is for the UA to use Open Payments to send payments rather than directly creating a STREAM connection.

The presumption is that the user has configured two services in the UA, a WM Provider (e.g. Coil) and their Open Payments enabled wallet (e.g. Uphold).

 - The WM Provider provides the configuration for how much to pay, who to pay etc
 - The wallet exposes [Open Payments APIs](https://docs.openpayments.guide) and during enrolment the browser stores access tokens that it can use to invoke these APIs on behalf of the user (e.g. to create an outgoing payment from the user's account).

The flow would be something like this:

1. User visits a website and the UA parses the Open Payments account endpoint (Payment Pointer) that was extracted from a link tag on the page.
2. Based on the WM Provider configuration the UA determines it should send 50c to the website at that endpoint.
3. UA calls out to the wallet to [create an outgoing payment](https://docs.openpayments.guide/reference/create-outgoing-payment) where the `receivingAccount` is the Payment Pointer and the `sendAmount` is 50c.
4. The wallet calls out to the monetization receiver (where the website has its account) and [creates an incoming payment](https://docs.openpayments.guide/reference/create-incoming-payment) with no fixed amount. It gets back a new unique URL for that `incomingPayment` resource.
5. The wallet updates the outgoing payment resource's `receivingPayment` property to be equal to the URL of the new payment it has just created. _(There is an exception condition if the receiver is a legacy wallet and only supports SPSP. This described below)_
6. The UA emits the monetization event with the amount of 50c and the URL of the incoming payment created at the monetization receiver as a new property: `incomingPayment`. The `receipt` property is deprecated.
7. The website can choose to:
  7.1 Trust the UA has sent the payment and act accordingly based on an amount sent of 50c.
  7.2 Poll the incoming payment to determine the amount received

This seems the best balance for UX and privacy too. 

- The website will get the monetisation event sooner (as soon as the payment is created by the UA at the user's wallet but not waiting for it to be sent and confirmed).
- The website can be optimistic and assume it has been paid but also asynchronously verify how much it actually received.
- The UA can emit the amount in whatever currency it wishes based on user preference (e.g. if it creates an AUD denominated outgoing payment at the user's wallet it could apply a conversion and emit an event in USD) as this is just an indicative value for the website. Using a standard currency or adapting the currency to the locale of the website protects the privacy of the user and possibly helps the website.
- The website can provide UX that makes sense to the user irrespective of the fees and exchange rate that might be applied (i.e. The user sent USD 0.50 so a thank you message of "thanks for the 045 EUR tip" would be kind of weird).
