### PR TITLE
fix: revert ill considered bigint usage for amount

### DIFF
--- a/static/specification.html
+++ b/static/specification.html
@@ -639,7 +639,7 @@
         [SecureContext, Exposed=Window]
         interface MonetizationEvent : Event {
           constructor(DOMString type, MonetizationEventInit eventInitDict);
-          readonly attribute bigint amount;
+          readonly attribute DOMString amount;
           readonly attribute DOMString assetCode;
           readonly attribute octet assetScale;
           readonly attribute DOMString? receipt;
@@ -648,7 +648,7 @@
         };
 
         dictionary MonetizationEventInit : EventInit {
-          required bigint amount;
+          required DOMString amount;
           required DOMString assetCode;
           required octet assetScale;
           required DOMString? receipt;


### PR DESCRIPTION
### BigInt Downsides

Need to monkey patch BigInt.prototype.toJSON for JSON.stringify to work
```typescript
export function extendPrimitives(): void {
  // Extend BigInt prototype for easier JSON stringification
  Object.defineProperty(BigInt.prototype, 'toJSON', {
    value: function (): string {
      return this.toString()
    }
  })
}
```

All operands must be BigInt in math operations
```
> BigInt(0) / 5
Uncaught TypeError: Cannot mix BigInt and other types, use explicit conversions
```

It is only a Big *Integer*, not an arbitrary precision, floating point Decimal. This means that when converting to floating point one must use number math. When using BigInt math, fractional amounts will round down to zero.

```
> const amount = BigInt(1)
> const assetScale = 2
> const assetCode = 'USD'
> console.log(`${assetCode}${amount / BigInt(Math.pow(10, assetScale))}`)
USD0
```

### BigInt Upsides