### PR TITLE
Fix import path for Link component

### DIFF
--- a/src/pages/exclusive-content.js
+++ b/src/pages/exclusive-content.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import { Container } from '@material-ui/core'
 import Layout from '@theme/Layout'
-import { Link } from '@docusaurus/router'
-import BrowserOnly from '@docusaurus/BrowserOnly';
+import Link from '@docusaurus/Link'
 
 import {
   ViewProvider,
@@ -14,7 +13,6 @@ export default function ExclusiveContent(props) {
   const { config: siteConfig } = props
 
   return (
-    <BrowserOnly>
     <Layout
       permalink='/exclusive-content'
       title={siteConfig.title}
@@ -40,6 +38,5 @@ export default function ExclusiveContent(props) {
         </ViewProvider>
       </ExclusiveContentProvider>
     </Layout>
-    </BrowserOnly>
   )
 }

--- a/src/pages/meta-tag.js
+++ b/src/pages/meta-tag.js
@@ -3,8 +3,7 @@ import { Container } from '@material-ui/core'
 import Checkbox from '@material-ui/core/Checkbox'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Layout from '@theme/Layout'
-import { Link } from '@docusaurus/router'
-import BrowserOnly from '@docusaurus/BrowserOnly'
+import Link from '@docusaurus/Link'
 
 export default function MetaTag(props) {
   const { config: siteConfig } = props
@@ -14,98 +13,96 @@ export default function MetaTag(props) {
   const [useVerifier, setUseVerifier] = useState(false)
 
   return (
-    <BrowserOnly>
-      <Layout
-        permalink='/meta-tag'
-        title={siteConfig.title}
-        description={siteConfig.tagLine}
-      >
-        <div className='docMainWrapper wrapper'>
-          <Container className='mainContainer documentContainer metaTagContainer'>
-            <header className='postHeader'>
-              <h1>Meta Tag Generator</h1>
-            </header>
-            <p>
-              This Meta Tag Generator helps you generate your HTML meta tag to
-              monetize your website.
-              <br />
-              Just provide your Payment Pointer and click generate.
-            </p>
-            <form
-              id='paymentPointerForm'
-              onSubmit={(ev) => ev.preventDefault()}
-            >
-              <input
-                className='paymentPointerInput'
-                type='text'
-                placeholder='$YourPaymentPointer'
-                onChange={(ev) => {
-                  setPointerInput(ev.target.value)
-                }}
-              />
-              <button
-                id='generateButton'
-                onClick={() => {
-                  setPointer(pointerInput)
-                }}
-              >
-                Generate
-              </button>
-            </form>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={useVerifier}
-                  onChange={(ev) => {
-                    setUseVerifier(ev.target.checked)
-                  }}
-                  color='default'
-                />
-              }
-              label={
-                <span>
-                  Use{' '}
-                  <Link
-                    to={
-                      '/docs/receipt-verifier/#use-our-publicly-available-receipt-verifier'
-                    }
-                  >
-                    receipt verifier service
-                  </Link>{' '}
-                  (Advanced)
-                </span>
-              }
+    <Layout
+      permalink='/meta-tag'
+      title={siteConfig.title}
+      description={siteConfig.tagLine}
+    >
+      <div className='docMainWrapper wrapper'>
+        <Container className='mainContainer documentContainer metaTagContainer'>
+          <header className='postHeader'>
+            <h1>Meta Tag Generator</h1>
+          </header>
+          <p>
+            This Meta Tag Generator helps you generate your HTML meta tag to
+            monetize your website.
+            <br />
+            Just provide your Payment Pointer and click generate.
+          </p>
+          <form
+            id='paymentPointerForm'
+            onSubmit={(ev) => ev.preventDefault()}
+          >
+            <input
+              className='paymentPointerInput'
+              type='text'
+              placeholder='$YourPaymentPointer'
+              onChange={(ev) => {
+                setPointerInput(ev.target.value)
+              }}
             />
+            <button
+              id='generateButton'
+              onClick={() => {
+                setPointer(pointerInput)
+              }}
+            >
+              Generate
+            </button>
+          </form>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={useVerifier}
+                onChange={(ev) => {
+                  setUseVerifier(ev.target.checked)
+                }}
+                color='default'
+              />
+            }
+            label={
+              <span>
+                Use{' '}
+                <Link
+                  to={
+                    '/docs/receipt-verifier/#use-our-publicly-available-receipt-verifier'
+                  }
+                >
+                  receipt verifier service
+                </Link>{' '}
+                (Advanced)
+              </span>
+            }
+          />
+          <p>
+            Read our <Link to='/docs'>docs</Link> to learn more about Web
+            Monetization. If you're interested in splitting revenue between
+            multiple parties, check out the{' '}
+            <Link to='/prob-revshare'>Probabilistic Revshare Generator</Link>.
+          </p>
+          <div className='metaTagOutput'>
             <p>
-              Read our <Link to='/docs'>docs</Link> to learn more about Web
-              Monetization. If you're interested in splitting revenue between
-              multiple parties, check out the{' '}
-              <Link to='/prob-revshare'>Probabilistic Revshare Generator</Link>.
+              To monetize your website add the following &lt;meta&gt; tag to
+              the &lt;head&gt; section of all pages on your website.
             </p>
-            <div className='metaTagOutput'>
-              <p>
-                To monetize your website add the following &lt;meta&gt; tag to
-                the &lt;head&gt; section of all pages on your website.
-              </p>
-              <code id='metaTag'>
-                &lt;meta name="monetization" content="
-                {useVerifier
-                  ? `$webmonetization.org/api/receipts/${encodeURIComponent(
-                      pointer
-                    )}`
-                  : pointer}
-                " /&gt;
-                <img
-                  src='/img/copy_icon.svg'
-                  id='copyIcon'
-                  className='btnClipboard'
-                  alt='copy-icon'
-                />
-              </code>
-            </div>
-          </Container>
-        </div>
-      </Layout>
-    </BrowserOnly>
+            <code id='metaTag'>
+              &lt;meta name="monetization" content="
+              {useVerifier
+                ? `$webmonetization.org/api/receipts/${encodeURIComponent(
+                    pointer
+                  )}`
+                : pointer}
+              " /&gt;
+              <img
+                src='/img/copy_icon.svg'
+                id='copyIcon'
+                className='btnClipboard'
+                alt='copy-icon'
+              />
+            </code>
+          </div>
+        </Container>
+      </div>
+    </Layout>
   )
 }

--- a/src/pages/prob-revshare.js
+++ b/src/pages/prob-revshare.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import { Container } from '@material-ui/core'
 import Layout from '@theme/Layout'
-import { Link } from '@docusaurus/router'
-import BrowserOnly from '@docusaurus/BrowserOnly'
+import Link from '@docusaurus/Link'
 
 import {
   SharesProvider,
@@ -14,7 +13,6 @@ export default function ProbRevshare(props) {
   const { config: siteConfig } = props
 
   return (
-    <BrowserOnly>
       <Layout
         permalink='/prob-revshare'
         title={siteConfig.title}
@@ -41,6 +39,5 @@ export default function ProbRevshare(props) {
           </SharesProvider>
         </ViewProvider>
       </Layout>
-    </BrowserOnly>
   )
 }


### PR DESCRIPTION
Closes https://github.com/WICG/webmonetization/issues/312

This PR resolves the error caused by `Link` component not imported correctly, hence causing the build to fail. Pages render as expected after updating the import path.
`BrowserOnly` is unnecessary and was removed.