### PR TITLE
Fix broken link causing CI failure

### DIFF
--- a/src/pages/meta-tag.js
+++ b/src/pages/meta-tag.js
@@ -44,7 +44,7 @@ export default function MetaTag(props) {
             monetize your website.
             <br />
             Just provide your{' '}
-            <Link to='/https://docs.openpayments.guide/docs/payment-pointers'>
+            <Link to='https://docs.openpayments.guide/docs/payment-pointers'>
               Payment Pointer
             </Link>{' '}
             and click generate.


### PR DESCRIPTION
I have a typo on one of the links on the Link Tag Generator page that requires fixing. It involves the deletion of an errant slash.

![Screenshot 2023-06-07 at 7 06 35 PM](https://github.com/WICG/webmonetization/assets/1461498/5fc67f74-1e2f-4434-9414-6ad86a3fdc69)
