### PR TITLE
Fix SVG issue on Firefox

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -217,6 +217,7 @@ section {
 .home-card--basic {
   max-width: 16em;
   justify-content: center;
+  width: 100%;
 }
 
 .home-card--basic img {


### PR DESCRIPTION
SVG on Firefox needs a width value if it is the only flex  child within the flex container.