### PR TITLE
Apply variable font sizing only to React pages

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -29,9 +29,12 @@
   --ifm-color-secondary-light: #2c3039;
   --ifm-color-secondary-lighter: #2e333c;
   --ifm-color-secondary-lightest: #343944;
-  --ifm-font-size-base: var(--step-0);
   --ifm-global-spacing: var(--space-s);
   --ifm-footer-link-color: var(--ifm-color-emphasis-300);
+}
+
+.plugin-pages .main-wrapper {
+  font-size: var(--step-0);
 }
 
 /* Typography styles */
@@ -72,6 +75,7 @@ section {
 
 /* Navigation styles */
 .navbar {
+  font-size: initial;
   width: 100%;
   padding-top: 8px;
   padding-bottom: 8px;


### PR DESCRIPTION
The previous update to the site styles have made the font sizing on the docs pages a tad too big. Moving the base font size change to impact ONLY the custom React pages. This also resolves the issue of the font size on the navbar causing the icons to wrap just before the breakpoint hits.


Problem:
![Screenshot 2023-06-08 at 10 27 25 AM](https://github.com/WICG/webmonetization/assets/1461498/c8c2fc25-1326-444c-8dce-b477e05e64a6)

Fix:
![Screenshot 2023-06-08 at 10 26 55 AM](https://github.com/WICG/webmonetization/assets/1461498/769f0b81-af21-4228-9280-ce6258369029)


Problem:
![Screenshot 2023-06-08 at 10 27 35 AM](https://github.com/WICG/webmonetization/assets/1461498/de61318c-96b7-4558-9010-fd90b7e7a315)

Fix:
![Screenshot 2023-06-08 at 10 38 18 AM](https://github.com/WICG/webmonetization/assets/1461498/c2f78c1e-7fff-49f4-81cc-a8503cacfe55)
