### PR TITLE
Update links in Resources section

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -222,17 +222,17 @@ export default function Index(props) {
             <Grid item sm={6} md={3}>
               <h3 className='heading--4'>Documentation</h3>
               <p>Resource on how to add Web Monetization to your site.</p>
-              <Link to='/docs/explainer'>Read docs ›</Link>
+              <Link to='/docs/web-monetization-api'>Read docs ›</Link>
             </Grid>
             <Grid item sm={6} md={3}>
               <h3 className='heading--4'>Explainer</h3>
               <p>The explainer submitted to the W3C.</p>
-              <Link to='/specification.html'>Read explainer ›</Link>
+              <Link to='/docs/explainer'>Read explainer ›</Link>
             </Grid>
             <Grid item sm={6} md={3}>
               <h3 className='heading--4'>Specification</h3>
               <p>The formal specification.</p>
-              <Link to='/specification.html'>Read specs ›</Link>
+              <Link to='pathname:///specification.html'>Read specs ›</Link>
             </Grid>
             <Grid item sm={6} md={3}>
               <h3 className='heading--4'>


### PR DESCRIPTION
Closes #334 

This PR fixes the "Page not found" issue with the 2 links in the Resources section. Upon further inspection, it seems that the first 3 links are incorrect and this has been rectified as well.

FYI, the specification, although accessible at https://webmonetization.org/specification.html, is not actually part of the SPA pages generated by Docusaurus, therefore we need to utilise the escape hatch of `pathname://` to resolve this (see https://docusaurus.io/docs/advanced/routing#escaping-from-spa-redirects)

**🎩 Top-hatting instructions (i.e. human testing that things are not broken)**

1. Pull this branch
2. Go to http://localhost:3000/ and scroll to the resources section. Verify that all links are working correctly.

