### PR TITLE
Add note for allow attribute

### DIFF
--- a/docs/permission-policy.md
+++ b/docs/permission-policy.md
@@ -21,7 +21,11 @@ Permissions-Policy: <directive> <allowlist>
 
 [`monetization`](/docs/permission-policy-monetization)
 
-Controls whether the current document is allowed to use the [Web Monetization API](/docs/).  
+Controls whether the current document is allowed to use the [Web Monetization API](/docs/).
+
+:::info Note
+The [`allow`](https://html.spec.whatwg.org/#attr-iframe-allow) attributes only take effect when the content navigable of the iframe is navigated. Adding or removing the monetization attribute has no effect on an already-loaded document.
+:::
 
 ## Example
 

--- a/static/specification-respec.html
+++ b/static/specification-respec.html
@@ -810,6 +810,9 @@
           disabled and related events won't be dispatched.
         </p>
       </aside>
+      <aside class="note">
+        <p>The <a href="https://html.spec.whatwg.org/#attr-iframe-allow">allow</a> attributes only take effect when the content navigable of the iframe is navigated. Adding or removing the monetization attribute has no effect on an already-loaded document.</p>
+      </aside>
     </section>
     <section data-cite="CSP">
       <h2>

--- a/static/specification/index.html
+++ b/static/specification/index.html
@@ -1,1853 +1,1856 @@
 <!DOCTYPE html><html lang="en"><head>
-<meta charset="utf-8">
-<meta name="generator" content="ReSpec 34.1.4">
-<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<style>
-span.example-title{text-transform:none}
-:is(aside,div).example,div.illegal-example{padding:.5em;margin:1em 0;position:relative;clear:both}
-div.illegal-example{color:red}
-div.illegal-example p{color:#000}
-:is(aside,div).example{border-left-width:.5em;border-left-style:solid;border-color:#e0cb52;background:#fcfaee}
-aside.example div.example{border-left-width:.1em;border-color:#999;background:#fff}
-.example pre{background-color:rgba(0,0,0,.03)}
-</style>
-<style>
-.issue-label{text-transform:initial}
-.warning>p:first-child{margin-top:0}
-.warning{padding:.5em;border-left-width:.5em;border-left-style:solid}
-span.warning{padding:.1em .5em .15em}
-.issue.closed span.issue-number{text-decoration:line-through}
-.issue.closed span.issue-number::after{content:" (Closed)";font-size:smaller}
-.warning{border-color:#f11;border-width:.2em;border-style:solid;background:#fbe9e9}
-.warning-title:before{content:"⚠";font-size:1.3em;float:left;padding-right:.3em;margin-top:-.3em}
-li.task-list-item{list-style:none}
-input.task-list-item-checkbox{margin:0 .35em .25em -1.6em;vertical-align:middle}
-.issue a.respec-gh-label{padding:5px;margin:0 2px 0 2px;font-size:10px;text-transform:none;text-decoration:none;font-weight:700;border-radius:4px;position:relative;bottom:2px;border:none;display:inline-block}
-</style>
-<style>
-pre.idl{padding:1em;position:relative}
-pre.idl>code{color:#000}
-@media print{
-pre.idl{white-space:pre-wrap}
-}
-.idlHeader{display:block;width:150px;background:#8ccbf2;color:#fff;font-family:sans-serif;font-weight:700;margin:-1em 0 1em -1em;height:28px;line-height:28px}
-.idlHeader a.self-link{margin-left:.3cm;text-decoration:none;border-bottom:none}
-.idlID{font-weight:700;color:#005a9c}
-.idlType{color:#005a9c}
-.idlName{color:#ff4500}
-.idlName a{color:#ff4500;border-bottom:1px dotted #ff4500;text-decoration:none}
-a.idlEnumItem{color:#000;border-bottom:1px dotted #ccc;text-decoration:none}
-.idlSuperclass{font-style:italic;color:#005a9c}
-.idlDefaultValue,.idlParamName{font-style:italic}
-.extAttr{color:#666}
-.idlSectionComment{color:gray}
-.idlIncludes a{font-weight:700}
-.respec-button-copy-paste:focus{text-decoration:none;border-color:#51a7e8;outline:0;box-shadow:0 0 5px rgba(81,167,232,.5)}
-.respec-button-copy-paste:is(:focus:hover,.selected:focus){border-color:#51a7e8}
-.respec-button-copy-paste:is(:hover,:active,.zeroclipboard-is-hover,.zeroclipboard-is-active){text-decoration:none;background-color:#ddd;background-image:linear-gradient(#eee,#ddd);border-color:#ccc}
-.respec-button-copy-paste:is(:active,.selected,.zeroclipboard-is-active){background-color:#dcdcdc;background-image:none;border-color:#b5b5b5;box-shadow:inset 0 2px 4px rgba(0,0,0,.15)}
-.respec-button-copy-paste.selected:hover{background-color:#cfcfcf}
-.respec-button-copy-paste:is(:disabled,:disabled:hover,.disabled,.disabled:hover){color:rgba(102,102,102,.5);cursor:default;background-color:rgba(229,229,229,.5);background-image:none;border-color:rgba(197,197,197,.5);box-shadow:none}
-@media print{
-.respec-button-copy-paste{visibility:hidden}
-}
-</style>
-<style>
-dfn{cursor:pointer}
-.dfn-panel{position:absolute;z-index:35;min-width:300px;max-width:500px;padding:.5em .75em;margin-top:.6em;font-family:"Helvetica Neue",sans-serif;font-size:small;background:#fff;color:#000;box-shadow:0 1em 3em -.4em rgba(0,0,0,.3),0 0 1px 1px rgba(0,0,0,.05);border-radius:2px}
-.dfn-panel:not(.docked)>.caret{position:absolute;top:-9px}
-.dfn-panel:not(.docked)>.caret::after,.dfn-panel:not(.docked)>.caret::before{content:"";position:absolute;border:10px solid transparent;border-top:0;border-bottom:10px solid #fff;top:0}
-.dfn-panel:not(.docked)>.caret::before{border-bottom:9px solid #a2a9b1}
-.dfn-panel *{margin:0}
-.dfn-panel b{display:block;color:#000;margin-top:.25em}
-.dfn-panel ul a[href]{color:#333}
-.dfn-panel>div{display:flex}
-.dfn-panel a.self-link{font-weight:700;margin-right:auto}
-.dfn-panel .marker{padding:.1em;margin-left:.5em;border-radius:.2em;text-align:center;white-space:nowrap;font-size:90%;color:#040b1c}
-.dfn-panel .marker.dfn-exported{background:#d1edfd;box-shadow:0 0 0 .125em #1ca5f940}
-.dfn-panel .marker.idl-block{background:#8ccbf2;box-shadow:0 0 0 .125em #0670b161}
-.dfn-panel a:not(:hover){text-decoration:none!important;border-bottom:none!important}
-.dfn-panel a[href]:hover{border-bottom-width:1px}
-.dfn-panel ul{padding:0}
-.dfn-panel li{margin-left:1em}
-.dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
-</style>
+  <meta charset="utf-8">
+  <meta name="generator" content="ReSpec 34.1.4">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <style>
+  span.example-title{text-transform:none}
+  :is(aside,div).example,div.illegal-example{padding:.5em;margin:1em 0;position:relative;clear:both}
+  div.illegal-example{color:red}
+  div.illegal-example p{color:#000}
+  :is(aside,div).example{border-left-width:.5em;border-left-style:solid;border-color:#e0cb52;background:#fcfaee}
+  aside.example div.example{border-left-width:.1em;border-color:#999;background:#fff}
+  .example pre{background-color:rgba(0,0,0,.03)}
+  </style>
+  <style>
+  .issue-label{text-transform:initial}
+  .warning>p:first-child{margin-top:0}
+  .warning{padding:.5em;border-left-width:.5em;border-left-style:solid}
+  span.warning{padding:.1em .5em .15em}
+  .issue.closed span.issue-number{text-decoration:line-through}
+  .issue.closed span.issue-number::after{content:" (Closed)";font-size:smaller}
+  .warning{border-color:#f11;border-width:.2em;border-style:solid;background:#fbe9e9}
+  .warning-title:before{content:"⚠";font-size:1.3em;float:left;padding-right:.3em;margin-top:-.3em}
+  li.task-list-item{list-style:none}
+  input.task-list-item-checkbox{margin:0 .35em .25em -1.6em;vertical-align:middle}
+  .issue a.respec-gh-label{padding:5px;margin:0 2px 0 2px;font-size:10px;text-transform:none;text-decoration:none;font-weight:700;border-radius:4px;position:relative;bottom:2px;border:none;display:inline-block}
+  </style>
+  <style>
+  pre.idl{padding:1em;position:relative}
+  pre.idl>code{color:#000}
+  @media print{
+  pre.idl{white-space:pre-wrap}
+  }
+  .idlHeader{display:block;width:150px;background:#8ccbf2;color:#fff;font-family:sans-serif;font-weight:700;margin:-1em 0 1em -1em;height:28px;line-height:28px}
+  .idlHeader a.self-link{margin-left:.3cm;text-decoration:none;border-bottom:none}
+  .idlID{font-weight:700;color:#005a9c}
+  .idlType{color:#005a9c}
+  .idlName{color:#ff4500}
+  .idlName a{color:#ff4500;border-bottom:1px dotted #ff4500;text-decoration:none}
+  a.idlEnumItem{color:#000;border-bottom:1px dotted #ccc;text-decoration:none}
+  .idlSuperclass{font-style:italic;color:#005a9c}
+  .idlDefaultValue,.idlParamName{font-style:italic}
+  .extAttr{color:#666}
+  .idlSectionComment{color:gray}
+  .idlIncludes a{font-weight:700}
+  .respec-button-copy-paste:focus{text-decoration:none;border-color:#51a7e8;outline:0;box-shadow:0 0 5px rgba(81,167,232,.5)}
+  .respec-button-copy-paste:is(:focus:hover,.selected:focus){border-color:#51a7e8}
+  .respec-button-copy-paste:is(:hover,:active,.zeroclipboard-is-hover,.zeroclipboard-is-active){text-decoration:none;background-color:#ddd;background-image:linear-gradient(#eee,#ddd);border-color:#ccc}
+  .respec-button-copy-paste:is(:active,.selected,.zeroclipboard-is-active){background-color:#dcdcdc;background-image:none;border-color:#b5b5b5;box-shadow:inset 0 2px 4px rgba(0,0,0,.15)}
+  .respec-button-copy-paste.selected:hover{background-color:#cfcfcf}
+  .respec-button-copy-paste:is(:disabled,:disabled:hover,.disabled,.disabled:hover){color:rgba(102,102,102,.5);cursor:default;background-color:rgba(229,229,229,.5);background-image:none;border-color:rgba(197,197,197,.5);box-shadow:none}
+  @media print{
+  .respec-button-copy-paste{visibility:hidden}
+  }
+  </style>
+  <style>
+  dfn{cursor:pointer}
+  .dfn-panel{position:absolute;z-index:35;min-width:300px;max-width:500px;padding:.5em .75em;margin-top:.6em;font-family:"Helvetica Neue",sans-serif;font-size:small;background:#fff;color:#000;box-shadow:0 1em 3em -.4em rgba(0,0,0,.3),0 0 1px 1px rgba(0,0,0,.05);border-radius:2px}
+  .dfn-panel:not(.docked)>.caret{position:absolute;top:-9px}
+  .dfn-panel:not(.docked)>.caret::after,.dfn-panel:not(.docked)>.caret::before{content:"";position:absolute;border:10px solid transparent;border-top:0;border-bottom:10px solid #fff;top:0}
+  .dfn-panel:not(.docked)>.caret::before{border-bottom:9px solid #a2a9b1}
+  .dfn-panel *{margin:0}
+  .dfn-panel b{display:block;color:#000;margin-top:.25em}
+  .dfn-panel ul a[href]{color:#333}
+  .dfn-panel>div{display:flex}
+  .dfn-panel a.self-link{font-weight:700;margin-right:auto}
+  .dfn-panel .marker{padding:.1em;margin-left:.5em;border-radius:.2em;text-align:center;white-space:nowrap;font-size:90%;color:#040b1c}
+  .dfn-panel .marker.dfn-exported{background:#d1edfd;box-shadow:0 0 0 .125em #1ca5f940}
+  .dfn-panel .marker.idl-block{background:#8ccbf2;box-shadow:0 0 0 .125em #0670b161}
+  .dfn-panel a:not(:hover){text-decoration:none!important;border-bottom:none!important}
+  .dfn-panel a[href]:hover{border-bottom-width:1px}
+  .dfn-panel ul{padding:0}
+  .dfn-panel li{margin-left:1em}
+  .dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
+  </style>
+      
+      
+  <title>Web Monetization</title>
+      
+      
     
-    
-<title>Web Monetization</title>
-    
-    
-  
-<style id="respec-mainstyle">
-@keyframes pop{
-0%{transform:scale(1,1)}
-25%{transform:scale(1.25,1.25);opacity:.75}
-100%{transform:scale(1,1)}
-}
-:is(h1,h2,h3,h4,h5,h6,a) abbr{border:none}
-dfn{font-weight:700}
-a.internalDFN{color:inherit;border-bottom:1px solid #99c;text-decoration:none}
-a.externalDFN{color:inherit;border-bottom:1px dotted #ccc;text-decoration:none}
-a.bibref{text-decoration:none}
-.respec-offending-element:target{animation:pop .25s ease-in-out 0s 1}
-.respec-offending-element,a[href].respec-offending-element{text-decoration:red wavy underline}
-@supports not (text-decoration:red wavy underline){
-.respec-offending-element:not(pre){display:inline-block}
-.respec-offending-element{background:url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x}
-}
-#references :target{background:#eaf3ff;animation:pop .4s ease-in-out 0s 1}
-cite .bibref{font-style:normal}
-a[href].orcid{padding-left:4px;padding-right:4px}
-a[href].orcid>svg{margin-bottom:-2px}
-.toc a,.tof a{text-decoration:none}
-a .figno,a .secno{color:#000}
-ol.tof,ul.tof{list-style:none outside none}
-.caption{margin-top:.5em;font-style:italic}
-table.simple{border-spacing:0;border-collapse:collapse;border-bottom:3px solid #005a9c}
-.simple th{background:#005a9c;color:#fff;padding:3px 5px;text-align:left}
-.simple th a{color:#fff;padding:3px 5px;text-align:left}
-.simple th[scope=row]{background:inherit;color:inherit;border-top:1px solid #ddd}
-.simple td{padding:3px 10px;border-top:1px solid #ddd}
-.simple tr:nth-child(even){background:#f0f6ff}
-.section dd>p:first-child{margin-top:0}
-.section dd>p:last-child{margin-bottom:0}
-.section dd{margin-bottom:1em}
-.section dl.attrs dd,.section dl.eldef dd{margin-bottom:0}
-#issue-summary>ul{column-count:2}
-#issue-summary li{list-style:none;display:inline-block}
-details.respec-tests-details{margin-left:1em;display:inline-block;vertical-align:top}
-details.respec-tests-details>*{padding-right:2em}
-details.respec-tests-details[open]{z-index:999999;position:absolute;border:thin solid #cad3e2;border-radius:.3em;background-color:#fff;padding-bottom:.5em}
-details.respec-tests-details[open]>summary{border-bottom:thin solid #cad3e2;padding-left:1em;margin-bottom:1em;line-height:2em}
-details.respec-tests-details>ul{width:100%;margin-top:-.3em}
-details.respec-tests-details>li{padding-left:1em}
-.self-link:hover{opacity:1;text-decoration:none;background-color:transparent}
-aside.example .marker>a.self-link{color:inherit}
-.header-wrapper{display:flex;align-items:baseline}
-:is(h2,h3,h4,h5,h6):not(#toc>h2,#abstract>h2,#sotd>h2,.head>h2){position:relative;left:-.5em}
-:is(h2,h3,h4,h5,h6):not(#toch2)+a.self-link{color:inherit;order:-1;position:relative;left:-1.1em;font-size:1rem;opacity:.5}
-:is(h2,h3,h4,h5,h6)+a.self-link::before{content:"§";text-decoration:none;color:var(--heading-text)}
-:is(h2,h3)+a.self-link{top:-.2em}
-:is(h4,h5,h6)+a.self-link::before{color:#000}
-@media (max-width:767px){
-dd{margin-left:0}
-}
-@media print{
-.removeOnSave{display:none}
-}
-</style>
-<meta name="description" content="Web Monetization allows websites to automatically receive payments from
-        users, facilitated by the user agent and a user's preferred
-        monetization provider.">
-<style>
-.hljs{display:block;overflow-x:auto;padding:.5em;color:#383a42;background:#fafafa}
-.hljs-comment,.hljs-quote{color:#717277;font-style:italic}
-.hljs-doctag,.hljs-formula,.hljs-keyword{color:#a626a4}
-.hljs-deletion,.hljs-name,.hljs-section,.hljs-selector-tag,.hljs-subst{color:#ca4706;font-weight:700}
-.hljs-literal{color:#0b76c5}
-.hljs-addition,.hljs-attribute,.hljs-meta-string,.hljs-regexp,.hljs-string{color:#42803c}
-.hljs-built_in,.hljs-class .hljs-title{color:#9a6a01}
-.hljs-attr,.hljs-number,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-pseudo,.hljs-template-variable,.hljs-type,.hljs-variable{color:#986801}
-.hljs-bullet,.hljs-link,.hljs-meta,.hljs-selector-id,.hljs-symbol,.hljs-title{color:#336ae3}
-.hljs-emphasis{font-style:italic}
-.hljs-strong{font-weight:700}
-.hljs-link{text-decoration:underline}
-</style>
-<style>
-var{position:relative;cursor:pointer}
-var[data-type]::after,var[data-type]::before{position:absolute;left:50%;top:-6px;opacity:0;transition:opacity .4s;pointer-events:none}
-var[data-type]::before{content:"";transform:translateX(-50%);border-width:4px 6px 0 6px;border-style:solid;border-color:transparent;border-top-color:#000}
-var[data-type]::after{content:attr(data-type);transform:translateX(-50%) translateY(-100%);background:#000;text-align:center;font-family:"Dank Mono","Fira Code",monospace;font-style:normal;padding:6px;border-radius:3px;color:#daca88;text-indent:0;font-weight:400}
-var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
-</style>
-<script id="initialUserConfig" type="application/json">{
-  "edDraftURI": "https://webmonetization.org/specification",
-  "github": {
-    "repoURL": "wicg/webmonetization",
-    "branch": "main"
-  },
-  "editors": [
-    {
-      "name": "Alex Lakatos",
-      "email": "alex@interledger.org",
-      "company": "Interledger Foundation",
-      "companyURL": "https://interledger.org/"
+  <style id="respec-mainstyle">
+  @keyframes pop{
+  0%{transform:scale(1,1)}
+  25%{transform:scale(1.25,1.25);opacity:.75}
+  100%{transform:scale(1,1)}
+  }
+  :is(h1,h2,h3,h4,h5,h6,a) abbr{border:none}
+  dfn{font-weight:700}
+  a.internalDFN{color:inherit;border-bottom:1px solid #99c;text-decoration:none}
+  a.externalDFN{color:inherit;border-bottom:1px dotted #ccc;text-decoration:none}
+  a.bibref{text-decoration:none}
+  .respec-offending-element:target{animation:pop .25s ease-in-out 0s 1}
+  .respec-offending-element,a[href].respec-offending-element{text-decoration:red wavy underline}
+  @supports not (text-decoration:red wavy underline){
+  .respec-offending-element:not(pre){display:inline-block}
+  .respec-offending-element{background:url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x}
+  }
+  #references :target{background:#eaf3ff;animation:pop .4s ease-in-out 0s 1}
+  cite .bibref{font-style:normal}
+  a[href].orcid{padding-left:4px;padding-right:4px}
+  a[href].orcid>svg{margin-bottom:-2px}
+  .toc a,.tof a{text-decoration:none}
+  a .figno,a .secno{color:#000}
+  ol.tof,ul.tof{list-style:none outside none}
+  .caption{margin-top:.5em;font-style:italic}
+  table.simple{border-spacing:0;border-collapse:collapse;border-bottom:3px solid #005a9c}
+  .simple th{background:#005a9c;color:#fff;padding:3px 5px;text-align:left}
+  .simple th a{color:#fff;padding:3px 5px;text-align:left}
+  .simple th[scope=row]{background:inherit;color:inherit;border-top:1px solid #ddd}
+  .simple td{padding:3px 10px;border-top:1px solid #ddd}
+  .simple tr:nth-child(even){background:#f0f6ff}
+  .section dd>p:first-child{margin-top:0}
+  .section dd>p:last-child{margin-bottom:0}
+  .section dd{margin-bottom:1em}
+  .section dl.attrs dd,.section dl.eldef dd{margin-bottom:0}
+  #issue-summary>ul{column-count:2}
+  #issue-summary li{list-style:none;display:inline-block}
+  details.respec-tests-details{margin-left:1em;display:inline-block;vertical-align:top}
+  details.respec-tests-details>*{padding-right:2em}
+  details.respec-tests-details[open]{z-index:999999;position:absolute;border:thin solid #cad3e2;border-radius:.3em;background-color:#fff;padding-bottom:.5em}
+  details.respec-tests-details[open]>summary{border-bottom:thin solid #cad3e2;padding-left:1em;margin-bottom:1em;line-height:2em}
+  details.respec-tests-details>ul{width:100%;margin-top:-.3em}
+  details.respec-tests-details>li{padding-left:1em}
+  .self-link:hover{opacity:1;text-decoration:none;background-color:transparent}
+  aside.example .marker>a.self-link{color:inherit}
+  .header-wrapper{display:flex;align-items:baseline}
+  :is(h2,h3,h4,h5,h6):not(#toc>h2,#abstract>h2,#sotd>h2,.head>h2){position:relative;left:-.5em}
+  :is(h2,h3,h4,h5,h6):not(#toch2)+a.self-link{color:inherit;order:-1;position:relative;left:-1.1em;font-size:1rem;opacity:.5}
+  :is(h2,h3,h4,h5,h6)+a.self-link::before{content:"§";text-decoration:none;color:var(--heading-text)}
+  :is(h2,h3)+a.self-link{top:-.2em}
+  :is(h4,h5,h6)+a.self-link::before{color:#000}
+  @media (max-width:767px){
+  dd{margin-left:0}
+  }
+  @media print{
+  .removeOnSave{display:none}
+  }
+  </style>
+  <meta name="description" content="Web Monetization allows websites to automatically receive payments from
+          users, facilitated by the user agent and a user's preferred
+          monetization provider.">
+  <style>
+  .hljs{display:block;overflow-x:auto;padding:.5em;color:#383a42;background:#fafafa}
+  .hljs-comment,.hljs-quote{color:#717277;font-style:italic}
+  .hljs-doctag,.hljs-formula,.hljs-keyword{color:#a626a4}
+  .hljs-deletion,.hljs-name,.hljs-section,.hljs-selector-tag,.hljs-subst{color:#ca4706;font-weight:700}
+  .hljs-literal{color:#0b76c5}
+  .hljs-addition,.hljs-attribute,.hljs-meta-string,.hljs-regexp,.hljs-string{color:#42803c}
+  .hljs-built_in,.hljs-class .hljs-title{color:#9a6a01}
+  .hljs-attr,.hljs-number,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-pseudo,.hljs-template-variable,.hljs-type,.hljs-variable{color:#986801}
+  .hljs-bullet,.hljs-link,.hljs-meta,.hljs-selector-id,.hljs-symbol,.hljs-title{color:#336ae3}
+  .hljs-emphasis{font-style:italic}
+  .hljs-strong{font-weight:700}
+  .hljs-link{text-decoration:underline}
+  </style>
+  <style>
+  var{position:relative;cursor:pointer}
+  var[data-type]::after,var[data-type]::before{position:absolute;left:50%;top:-6px;opacity:0;transition:opacity .4s;pointer-events:none}
+  var[data-type]::before{content:"";transform:translateX(-50%);border-width:4px 6px 0 6px;border-style:solid;border-color:transparent;border-top-color:#000}
+  var[data-type]::after{content:attr(data-type);transform:translateX(-50%) translateY(-100%);background:#000;text-align:center;font-family:"Dank Mono","Fira Code",monospace;font-style:normal;padding:6px;border-radius:3px;color:#daca88;text-indent:0;font-weight:400}
+  var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
+  </style>
+  <script id="initialUserConfig" type="application/json">{
+    "edDraftURI": "https://webmonetization.org/specification",
+    "github": {
+      "repoURL": "wicg/webmonetization",
+      "branch": "main"
     },
-    {
-      "name": "Adrian Hope-Bailie",
-      "email": "adrian@fynbos.dev",
-      "company": "Fynbos Technologies Limited",
-      "companyURL": "https://fynbos.dev"
+    "editors": [
+      {
+        "name": "Alex Lakatos",
+        "email": "alex@interledger.org",
+        "company": "Interledger Foundation",
+        "companyURL": "https://interledger.org/"
+      },
+      {
+        "name": "Adrian Hope-Bailie",
+        "email": "adrian@fynbos.dev",
+        "company": "Fynbos Technologies Limited",
+        "companyURL": "https://fynbos.dev"
+      },
+      {
+        "name": "Nicholas Dudfield",
+        "email": "niq@coil.com",
+        "company": "Coil Technologies Inc.",
+        "companyURL": "https://coil.com"
+      }
+    ],
+    "formerEditors": [
+      {
+        "name": "Ben Sharafian",
+        "email": "ben@coil.com",
+        "company": "Coil Technologies Inc.",
+        "companyURL": "https://coil.com",
+        "retiredDate": "2022-02-01"
+      },
+      {
+        "name": "Marcos Caceres",
+        "company": "W3C",
+        "companyURL": "https://w3.org/",
+        "retiredDate": "2022-03-23"
+      }
+    ],
+    "shortName": "web-monetization",
+    "specStatus": "CG-DRAFT",
+    "group": "wicg",
+    "xref": "web-platform",
+    "localBiblio": {
+      "Interledger": {
+        "title": "Interledger Protocol",
+        "href": "https://interledger.org/rfcs/0027-interledger-protocol-4/",
+        "id": "interledger"
+      },
+      "STREAM": {
+        "title": "STREAM",
+        "href": "https://interledger.org/rfcs/0029-stream/",
+        "id": "stream"
+      },
+      "Receipt": {
+        "title": "STREAM Receipt",
+        "href": "https://interledger.org/rfcs/0039-stream-receipts/",
+        "id": "receipt"
+      },
+      "Open Payments": {
+        "title": "Open Payments",
+        "href": "https://docs.openpayments.guide/",
+        "id": "open payments"
+      }
     },
-    {
-      "name": "Nicholas Dudfield",
-      "email": "niq@coil.com",
-      "company": "Coil Technologies Inc.",
-      "companyURL": "https://coil.com"
-    }
-  ],
-  "formerEditors": [
-    {
-      "name": "Ben Sharafian",
-      "email": "ben@coil.com",
-      "company": "Coil Technologies Inc.",
-      "companyURL": "https://coil.com",
-      "retiredDate": "2022-02-01"
-    },
-    {
-      "name": "Marcos Caceres",
-      "company": "W3C",
-      "companyURL": "https://w3.org/",
-      "retiredDate": "2022-03-23"
-    }
-  ],
-  "shortName": "web-monetization",
-  "specStatus": "CG-DRAFT",
-  "group": "wicg",
-  "xref": "web-platform",
-  "localBiblio": {
-    "Interledger": {
-      "title": "Interledger Protocol",
-      "href": "https://interledger.org/rfcs/0027-interledger-protocol-4/",
-      "id": "interledger"
-    },
-    "STREAM": {
-      "title": "STREAM",
-      "href": "https://interledger.org/rfcs/0029-stream/",
-      "id": "stream"
-    },
-    "Receipt": {
-      "title": "STREAM Receipt",
-      "href": "https://interledger.org/rfcs/0039-stream-receipts/",
-      "id": "receipt"
-    },
-    "Open Payments": {
-      "title": "Open Payments",
-      "href": "https://docs.openpayments.guide/",
-      "id": "open payments"
-    }
-  },
-  "publishISODate": "2023-07-05T00:00:00.000Z",
-  "generatedSubtitle": "Draft Community Group Report 05 July 2023"
-}</script>
-<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/cg-draft"></head>
-  <body class="h-entry" data-cite="WEBIDL HTML INFRA URL WEBIDL DOM FETCH"><div class="head">
-    
-    <h1 id="title" class="title">Web Monetization</h1> 
-    <p id="w3c-state">
-      <a href="https://www.w3.org/standards/types#reports">Draft Community Group Report</a>
-      <time class="dt-published" datetime="2023-07-05">05 July 2023</time>
-    </p>
-    <dl>
+    "publishISODate": "2023-07-07T00:00:00.000Z",
+    "generatedSubtitle": "Draft Community Group Report 07 July 2023"
+  }</script>
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/cg-draft"></head>
+    <body class="h-entry" data-cite="WEBIDL HTML INFRA URL WEBIDL DOM FETCH"><div class="head">
       
-      <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/web-monetization/">https://www.w3.org/web-monetization/</a>
-            </dd>
-      <dt>Latest editor's draft:</dt><dd><a href="https://webmonetization.org/specification">https://webmonetization.org/specification</a></dd>
-      
-      
-      
-      
-      <dt>Editors:</dt><dd class="editor p-author h-card vcard">
-    <span class="p-name fn">Alex Lakatos</span> (<a class="p-org org h-org" href="https://interledger.org/">Interledger Foundation</a>)
-  </dd><dd class="editor p-author h-card vcard">
-    <span class="p-name fn">Adrian Hope-Bailie</span> (<a class="p-org org h-org" href="https://fynbos.dev">Fynbos Technologies Limited</a>)
-  </dd><dd class="editor p-author h-card vcard">
-    <span class="p-name fn">Nicholas Dudfield</span> (<a class="p-org org h-org" href="https://coil.com">Coil Technologies Inc.</a>)
-  </dd>
-      <dt>
-              Former editors:
-            </dt><dd class="editor p-author h-card vcard">
-    <span class="p-name fn">Ben Sharafian</span> (<a class="p-org org h-org" href="https://coil.com">Coil Technologies Inc.</a>) -  Until <time datetime="2022-02-01">01 February 2022</time>
-  </dd><dd class="editor p-author h-card vcard">
-    <span class="p-name fn">Marcos Caceres</span> (<a class="p-org org h-org" href="https://w3.org/">W3C</a>) -  Until <time datetime="2022-03-23">23 March 2022</time>
-  </dd>
-      
-      <dt>Feedback:</dt><dd>
-        <a href="https://github.com/wicg/webmonetization/">GitHub wicg/webmonetization</a>
-        (<a href="https://github.com/wicg/webmonetization/pulls/">pull requests</a>,
-        <a href="https://github.com/wicg/webmonetization/issues/new/choose">new issue</a>,
-        <a href="https://github.com/wicg/webmonetization/issues/">open issues</a>)
-      </dd>
-      
-    </dl>
-    
-    <p class="copyright">
-          <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>
-          ©
-          2023
-          
-          the Contributors to the Web Monetization
-          Specification, published by the
-          <a href="https://www.w3.org/groups/cg/wicg">Web Platform Incubator Community Group</a> under the
-          <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable
-                <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a>
-                is available.
-              
-        </p>
-    <hr title="Separator for header">
-  </div>
-    <section id="abstract" class="introductory"><h2>Abstract</h2>
-      <p>
-        Web Monetization allows websites to automatically receive payments from
-        users, facilitated by the user agent and a user's preferred
-        monetization provider.
+      <h1 id="title" class="title">Web Monetization</h1> 
+      <p id="w3c-state">
+        <a href="https://www.w3.org/standards/types#reports">Draft Community Group Report</a>
+        <time class="dt-published" datetime="2023-07-07">07 July 2023</time>
       </p>
-    </section>
-    <section id="sotd" class="introductory"><h2>Status of This Document</h2><p>
-      This specification was published by the
-      <a href="https://www.w3.org/groups/cg/wicg">Web Platform Incubator Community Group</a>. It is not a W3C Standard nor is it
-      on the W3C Standards Track.
-      
-            Please note that under the
-            <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>
-            there is a limited opt-out and other conditions apply.
-          
-      Learn more about
-      <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>.
-    </p>
-      <div class="warning" id="issue-container-generatedID"><div role="heading" class="warning-title marker" id="h-warning" aria-level="3"><span>Warning</span></div><div class="">
-        <p>
-          This specification is a work in progress within the community on the
-          best shape it should take. Please see the <a href="./docs/explainer">explainer</a> for more info.
-        </p>
-        <p>
-          The specification reflects the desired end-state of the Web
-          Monetization APIs as currently anticipated and agreed to between the
-          contributors. The specification is being prepared here, in this
-          format, to collect the input of the Web community and prepare the
-          work to ultimately follow the W3C standards track should it have the
-          necessary support to do so.
-        </p>
-        <p>
-          For the most accurate reflection of the APIs that have been
-          implemented by providers see the <a href="./docs/api">API
-          documentation</a>.
-        </p>
-      </div></div>
-    <p>
-    <a href="https://github.com/wicg/webmonetization/issues/">GitHub Issues</a> are preferred for
-          discussion of this specification.
-        
-    
-  </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#abstract">Abstract</a></li><li class="tocline"><a class="tocxref" href="#sotd">Status of This Document</a></li><li class="tocline"><a class="tocxref" href="#usage-examples"><bdi class="secno">1. </bdi>
-        Usage examples
-      </a><ol class="toc"><li class="tocline"><a class="tocxref" href="#checking-if-web-monetization-is-supported"><bdi class="secno">1.1 </bdi>
-          Checking if Web Monetization is supported
-        </a></li><li class="tocline"><a class="tocxref" href="#monetizing-a-web-page"><bdi class="secno">1.2 </bdi>
-          Monetizing a web page
-        </a></li><li class="tocline"><a class="tocxref" href="#monetization-events"><bdi class="secno">1.3 </bdi>
-          Monetization events
-        </a></li><li class="tocline"><a class="tocxref" href="#verifying-a-payment"><bdi class="secno">1.4 </bdi>
-          Verifying a payment
-        </a></li><li class="tocline"><a class="tocxref" href="#monetizing-media"><bdi class="secno">1.5 </bdi>
-          Monetizing media
-        </a></li></ol></li><li class="tocline"><a class="tocxref" href="#model"><bdi class="secno">2. </bdi>
-        Model
-      </a></li><li class="tocline"><a class="tocxref" href="#goals"><bdi class="secno">3. </bdi>
-        Goals
-      </a></li><li class="tocline"><a class="tocxref" href="#link-type-monetization"><bdi class="secno">4. </bdi>
-        Link type "monetization"
-      </a></li><li class="tocline"><a class="tocxref" href="#onmonetization-event-handler"><bdi class="secno">5. </bdi>
-        <code>onmonetization</code> event handler
-      </a></li><li class="tocline"><a class="tocxref" href="#events"><bdi class="secno">6. </bdi>
-        monetization event
-      </a></li><li class="tocline"><a class="tocxref" href="#task-sources"><bdi class="secno">7. </bdi>
-        Task sources
-      </a></li><li class="tocline"><a class="tocxref" href="#monetizationcurrencyamount-interface"><bdi class="secno">8. </bdi>
-        <code>MonetizationCurrencyAmount</code> interface
-      </a><ol class="toc"><li class="tocline"><a class="tocxref" href="#currency-member"><bdi class="secno">8.1 </bdi>
-          <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="currency" data-dfn-for="MonetizationCurrencyAmount" data-type="DOMString" data-lt="currency" data-local-lt="MonetizationCurrencyAmount.currency"><code>currency</code></span> member
-        </a></li><li class="tocline"><a class="tocxref" href="#value-member"><bdi class="secno">8.2 </bdi>
-          <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="value" data-dfn-for="MonetizationCurrencyAmount" data-type="DOMString" data-lt="value" data-local-lt="MonetizationCurrencyAmount.value"><code>value</code></span> member
-        </a></li></ol></li><li class="tocline"><a class="tocxref" href="#monetizationevent-interface"><bdi class="secno">9. </bdi>
-        <code>MonetizationEvent</code> interface
-      </a><ol class="toc"><li class="tocline"><a class="tocxref" href="#amount-attribute-deprecated"><bdi class="secno">9.1 </bdi>
-          <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="amount" data-dfn-for="MonetizationEvent" data-type="DOMString" data-lt="amount" data-local-lt="MonetizationEvent.amount"><code>amount</code></span> attribute (deprecated)
-        </a></li><li class="tocline"><a class="tocxref" href="#assetcode-attribute-deprecated"><bdi class="secno">9.2 </bdi>
-          <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="assetCode" data-dfn-for="MonetizationEvent" data-type="DOMString" data-lt="assetCode" data-local-lt="MonetizationEvent.assetCode"><code>assetCode</code></span> attribute (deprecated)
-        </a></li><li class="tocline"><a class="tocxref" href="#assetscale-attribute-deprecated"><bdi class="secno">9.3 </bdi>
-          <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="assetScale" data-dfn-for="MonetizationEvent" data-type="octet" data-lt="assetScale" data-local-lt="MonetizationEvent.assetScale"><code>assetScale</code></span> attribute (deprecated)
-        </a></li><li class="tocline"><a class="tocxref" href="#amountsent-attribute"><bdi class="secno">9.4 </bdi>
-          <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="amountSent" data-dfn-for="MonetizationEvent" data-type="MonetizationCurrencyAmount" data-lt="amountSent" data-local-lt="MonetizationEvent.amountSent"><code>amountSent</code></span> attribute
-        </a></li><li class="tocline"><a class="tocxref" href="#receipt-attribute-deprecated"><bdi class="secno">9.5 </bdi>
-          <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="receipt" data-dfn-for="MonetizationEvent" data-type="DOMString" data-lt="receipt" data-local-lt="MonetizationEvent.receipt"><code>receipt</code></span> attribute (deprecated)
-        </a></li><li class="tocline"><a class="tocxref" href="#paymentpointer-attribute"><bdi class="secno">9.6 </bdi>
-          <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="paymentPointer" data-dfn-for="MonetizationEvent" data-type="USVString" data-lt="paymentPointer" data-local-lt="MonetizationEvent.paymentPointer"><code>paymentPointer</code></span> attribute
-        </a></li><li class="tocline"><a class="tocxref" href="#incomingpayment-attribute"><bdi class="secno">9.7 </bdi>
-          <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="incomingPayment" data-dfn-for="MonetizationEvent" data-type="USVString" data-lt="incomingPayment" data-local-lt="MonetizationEvent.incomingPayment"><code>incomingPayment</code></span> attribute
-        </a></li></ol></li><li class="tocline"><a class="tocxref" href="#permissions-policy"><bdi class="secno">10. </bdi>
-        Permissions Policy integration
-      </a></li><li class="tocline"><a class="tocxref" href="#content-security-policy"><bdi class="secno">11. </bdi>
-        Content Security Policy
-      </a><ol class="toc"><li class="tocline"><a class="tocxref" href="#monetization-src-directive"><bdi class="secno">11.1 </bdi>
-          <span class="export" data-export="">monetization-src</span> directive
-        </a><ol class="toc"><li class="tocline"><a class="tocxref" href="#monetization-src-pre-request-check"><bdi class="secno">11.1.1 </bdi>
-            <code>monetization-src</code> Pre-request check
-          </a></li><li class="tocline"><a class="tocxref" href="#monetization-src-post-request-check"><bdi class="secno">11.1.2 </bdi>
-            <code>monetization-src</code> Post-request check
-          </a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#security-considerations"><bdi class="secno">12. </bdi>
-        Security considerations
-      </a></li><li class="tocline"><a class="tocxref" href="#privacy-considerations"><bdi class="secno">13. </bdi>
-        Privacy considerations
-      </a></li><li class="tocline"><a class="tocxref" href="#relation-to-other-technologies"><bdi class="secno">14. </bdi>
-        Relation to Web Payments
-      </a></li><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">A. </bdi>Conformance</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">B. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">B.1 </bdi>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">B.2 </bdi>Informative references</a></li></ol></li></ol></nav>
-    <section class="informative" id="usage-examples"><div class="header-wrapper"><h2 id="x1-usage-examples"><bdi class="secno">1. </bdi>
-        Usage examples
-      </h2><a class="self-link" href="#usage-examples" aria-label="Permalink for Section 1."></a></div><p><em>This section is non-normative.</em></p>
-      
-      <section id="checking-if-web-monetization-is-supported"><div class="header-wrapper"><h3 id="x1-1-checking-if-web-monetization-is-supported"><bdi class="secno">1.1 </bdi>
-          Checking if Web Monetization is supported
-        </h3><a class="self-link" href="#checking-if-web-monetization-is-supported" aria-label="Permalink for Section 1.1"></a></div>
-        
-        <p>
-          There are multiple ways to check if Web Monetization is supported.
-          One way is to call <a data-link-type="idl" data-lt="supports()" data-type="method" href="https://dom.spec.whatwg.org/#dom-domtokenlist-supports"><code>supports</code></a><code>()</code> on a <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code>
-          element's <a data-link-type="idl" data-type="attribute" href="https://html.spec.whatwg.org/multipage/semantics.html#dom-link-rellist"><code>relList</code></a> passing the <code>"monetization"</code>
-          keyword. Alternatively, you can check if either the
-          <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-1"><code>MonetizationEvent</code></a> interface or the "<code>onmonetization</code>" <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">event handler IDL attribute</a> exist on the <a data-link-type="idl" data-lt="Window" data-type="interface" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window"><code>Window</code></a> object.
-        </p>
-        <aside class="example" id="example-1"><div class="marker">
-    <a class="self-link" href="#example-1">Example<bdi> 1</bdi></a>
-  </div>
-          <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">link</span> <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.com/monetization.js"</span>&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
-  <span class="hljs-comment">// Checking via DOMTokenList</span>
-  <span class="hljs-keyword">const</span> link = <span class="hljs-built_in">document</span>.querySelector(<span class="hljs-string">'link[rel="monetization"]'</span>) ||
-    <span class="hljs-built_in">document</span>.createElement(<span class="hljs-string">"link"</span>);
-  <span class="hljs-keyword">if</span> (link.relList.supports(<span class="hljs-string">"monetization"</span>)) {
-    <span class="hljs-built_in">console</span>.log(<span class="hljs-string">"Web Monetization is supported."</span>);
-  }
-
-  <span class="hljs-comment">// Checking global scope for MonetizationEvent</span>
-  <span class="hljs-keyword">if</span> (<span class="hljs-built_in">window</span>.MonetizationEvent) {
-    <span class="hljs-built_in">console</span>.log(<span class="hljs-string">"Web Monetization is supported."</span>);
-  }
-
-  <span class="hljs-comment">// Checking if it's a global event handler</span>
-  <span class="hljs-keyword">if</span> (<span class="hljs-built_in">window</span>.hasOwnProperty(<span class="hljs-string">"onmonetization"</span>)) {
-    <span class="hljs-built_in">console</span>.log(<span class="hljs-string">"Web Monetization is supported."</span>);
-  }
-</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></code></pre>
-        </aside>
-      </section>
-      <section id="monetizing-a-web-page"><div class="header-wrapper"><h3 id="x1-2-monetizing-a-web-page"><bdi class="secno">1.2 </bdi>
-          Monetizing a web page
-        </h3><a class="self-link" href="#monetizing-a-web-page" aria-label="Permalink for Section 1.2"></a></div>
-        
-        <aside class="example" id="example-2"><div class="marker">
-    <a class="self-link" href="#example-2">Example<bdi> 2</bdi></a>
-  </div>
-          <pre aria-busy="false"><code class="hljs html"><span class="hljs-meta">&lt;!DOCTYPE <span class="hljs-meta-keyword">html</span>&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">html</span> <span class="hljs-attr">lang</span>=<span class="hljs-string">"en"</span>&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">meta</span> <span class="hljs-attr">charset</span>=<span class="hljs-string">"utf-8"</span>&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">title</span>&gt;</span>My Blog<span class="hljs-tag">&lt;/<span class="hljs-name">title</span>&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">link</span>
-  <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span>
-  <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.com/pay"</span>
-  <span class="hljs-attr">onmonetization</span>=<span class="hljs-string">"sayThanks(this)"</span>&gt;</span>
-
-<span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
-  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">sayThanks</span>(<span class="hljs-params">monetizedLink</span>) </span>{
-    <span class="hljs-comment">// Do something here</span>
-  }
-</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></code></pre>
-        </aside>
-      </section>
-      <section id="monetization-events"><div class="header-wrapper"><h3 id="x1-3-monetization-events"><bdi class="secno">1.3 </bdi>
-          Monetization events
-        </h3><a class="self-link" href="#monetization-events" aria-label="Permalink for Section 1.3"></a></div>
-        
-        <p>
-          The <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-2"><code>MonetizationEvent</code></a> DOM events provide information such as the
-          amount sent, the currency of the payment, and a link to the incoming
-          payment at the <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-1">monetization receiver</a> which can be used to verify
-          the receipt of payment. As in the previous example above, these
-          events are dispatched to <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> elements and bubble up the DOM
-          tree.
-        </p>
-        <p>
-          To listen for <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-3"><code>MonetizationEvent</code></a> events, an <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-listener">event listener</a>
-          needs to be added to the relevant <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element (or to one of its
-          ancestors) via JavaScript:
-        </p>
-        <aside class="example" id="example-3"><div class="marker">
-    <a class="self-link" href="#example-3">Example<bdi> 3</bdi></a>
-  </div>
-          <pre aria-busy="false"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">link</span> <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.com/pay"</span>&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
-  <span class="hljs-keyword">const</span> link = <span class="hljs-built_in">document</span>.querySelector(<span class="hljs-string">'link[rel="monetization"]'</span>);
-  link.addEventListener(<span class="hljs-string">"monetization"</span>, <span class="hljs-function"><span class="hljs-params">event</span> =&gt;</span> {
-    <span class="hljs-comment">// See how much was sent and in what currency</span>
-    <span class="hljs-keyword">const</span> { <span class="hljs-attr">amountSent</span> : { value, currency }} = event;
-    <span class="hljs-built_in">console</span>.log(<span class="hljs-string">`Browser sent <span class="hljs-subst">${currency}</span> <span class="hljs-subst">${value}</span>.`</span>);
-
-    <span class="hljs-comment">// Use the incoming payment URL to verify the payment at the receiver.</span>
-    verifyPayment(event);
-  });
-</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></code></pre>
-        </aside>
-      </section>
-      <section id="verifying-a-payment"><div class="header-wrapper"><h3 id="x1-4-verifying-a-payment"><bdi class="secno">1.4 </bdi>
-          Verifying a payment
-        </h3><a class="self-link" href="#verifying-a-payment" aria-label="Permalink for Section 1.4"></a></div>
-        
-        <p>
-          The <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-4"><code>MonetizationEvent</code></a>'s <a data-link-type="idl" href="#dom-monetizationevent-incomingpayment" class="internalDFN" id="ref-for-dom-monetizationevent-incomingpayment-1"><code>incomingPayment</code></a>
-          attribute is a URL that can be used to verify the payment at the
-          <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-2">monetization receiver</a>.
-        </p>
-        <p>
-          In most cases requests to the <a data-link-type="idl" href="#dom-monetizationevent-incomingpayment" class="internalDFN" id="ref-for-dom-monetizationevent-incomingpayment-2"><code>incomingPayment</code></a>
-          URL will need to be authenticated as they fetch sensitive details
-          such as the <code>receivedAmount</code>. The specifics of this authentication
-          are agreed by the website and the <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-3">monetization receiver</a> when
-          setting up the receiving account.
-        </p>
-        <p>
-          Below is a hypothetical naive verification method that will make a
-          request to the <a data-link-type="idl" href="#dom-monetizationevent-incomingpayment" class="internalDFN" id="ref-for-dom-monetizationevent-incomingpayment-3"><code>incomingPayment</code></a> URL and simply
-          return the results. For simplicity it has no logic for authenticating
-          the request.
-        </p>
-        <p>
-          A more sophisticated implementation should track the <code>receivedAmount</code>
-          property and ensure it is increasing after each <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-5"><code>MonetizationEvent</code></a>
-          to verify that a new payment has been received.
-        </p>
-        <aside class="example" id="example-4"><div class="marker">
-    <a class="self-link" href="#example-4">Example<bdi> 4</bdi></a>
-  </div>
-          <pre class="JS" aria-busy="false"><code class="hljs js"><span class="hljs-comment">/** <span class="hljs-doctag">@type <span class="hljs-type">{MonetizationEvent}</span> </span>event */</span>
-<span class="hljs-keyword">async</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">verifyPayment</span>(<span class="hljs-params">event</span>) </span>{
-  <span class="hljs-comment">// Legacy receivers don't support returning incoming payment URLs</span>
-  <span class="hljs-keyword">if</span>(!event.incomingPayment){
-    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">'No incoming payment URL'</span>)
-  }
-
-  <span class="hljs-comment">// Poll the incoming payment to check the amount received</span>
-  <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> fetch(event.incomingPayment, {
-    <span class="hljs-attr">credentials</span>: <span class="hljs-string">'same-origin'</span>,
-    <span class="hljs-attr">mode</span>: <span class="hljs-string">'same-origin'</span>,
-    <span class="hljs-attr">cache</span>: <span class="hljs-string">'no-cache'</span>,
-    <span class="hljs-attr">headers</span>: {
-      <span class="hljs-string">'Content-Type'</span>: <span class="hljs-string">'application/json'</span>
-    }
-  });
-
-  <span class="hljs-keyword">if</span> (response.ok) {
-    <span class="hljs-comment">// The incoming payment was fetched successfully</span>
-    <span class="hljs-keyword">const</span> { receivedAmount } = <span class="hljs-built_in">JSON</span>.parse(<span class="hljs-keyword">await</span> response.json())
-    <span class="hljs-keyword">const</span> { amount, assetCode, assetScale } = receivedAmount;
-    <span class="hljs-built_in">console</span>.log(<span class="hljs-string">`Received <span class="hljs-subst">${assetCode}</span><span class="hljs-subst">${amount / (<span class="hljs-number">10</span> ** assetScale)}</span>.`</span>);
-    <span class="hljs-keyword">return</span> receivedAmount;
-  }
-}</code></pre>
-        </aside>
-      </section>
-      <section id="monetizing-media"><div class="header-wrapper"><h3 id="x1-5-monetizing-media"><bdi class="secno">1.5 </bdi>
-          Monetizing media
-        </h3><a class="self-link" href="#monetizing-media" aria-label="Permalink for Section 1.5"></a></div>
-        
-        <p>
-          The following example shows how to monetize various types of media
-          using different <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-1">payment pointers</a>.
-        </p>
-        <aside class="example" id="example-5"><div class="marker">
-    <a class="self-link" href="#example-5">Example<bdi> 5</bdi></a>
-  </div>
-          <pre aria-busy="false"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">video</span> <span class="hljs-attr">src</span>=<span class="hljs-string">"myvideo"</span> <span class="hljs-attr">onmonetization</span>=<span class="hljs-string">"sayThanks(this)"</span>&gt;</span>
-  <span class="hljs-tag">&lt;<span class="hljs-name">link</span> <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.com/video/pay"</span>&gt;</span>
-<span class="hljs-tag">&lt;/<span class="hljs-name">video</span>&gt;</span>
-
-<span class="hljs-tag">&lt;<span class="hljs-name">audio</span> <span class="hljs-attr">src</span>=<span class="hljs-string">"music.mp3"</span> <span class="hljs-attr">onmonetization</span>=<span class="hljs-string">"sayThanks(this)"</span>&gt;</span>
-  <span class="hljs-tag">&lt;<span class="hljs-name">link</span> <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.com/audio/pay"</span>&gt;</span>
-<span class="hljs-tag">&lt;/<span class="hljs-name">audio</span>&gt;</span>
-
-<span class="hljs-tag">&lt;<span class="hljs-name">picture</span> <span class="hljs-attr">srcset</span>=<span class="hljs-string">"cat.jpeg"</span> <span class="hljs-attr">onmonetization</span>=<span class="hljs-string">"sayThanks(this)"</span>&gt;</span>
-  <span class="hljs-tag">&lt;<span class="hljs-name">link</span> <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.com/images/pay"</span>&gt;</span>
-<span class="hljs-tag">&lt;/<span class="hljs-name">picture</span>&gt;</span></code></pre>
-        </aside>
-      </section>
-    </section>
-    <section id="model"><div class="header-wrapper"><h2 id="x2-model"><bdi class="secno">2. </bdi>
-        Model
-      </h2><a class="self-link" href="#model" aria-label="Permalink for Section 2."></a></div>
-      
       <dl>
+        
+        <dt>Latest published version:</dt><dd>
+                <a href="https://www.w3.org/web-monetization/">https://www.w3.org/web-monetization/</a>
+              </dd>
+        <dt>Latest editor's draft:</dt><dd><a href="https://webmonetization.org/specification">https://webmonetization.org/specification</a></dd>
+        
+        
+        
+        
+        <dt>Editors:</dt><dd class="editor p-author h-card vcard">
+      <span class="p-name fn">Alex Lakatos</span> (<a class="p-org org h-org" href="https://interledger.org/">Interledger Foundation</a>)
+    </dd><dd class="editor p-author h-card vcard">
+      <span class="p-name fn">Adrian Hope-Bailie</span> (<a class="p-org org h-org" href="https://fynbos.dev">Fynbos Technologies Limited</a>)
+    </dd><dd class="editor p-author h-card vcard">
+      <span class="p-name fn">Nicholas Dudfield</span> (<a class="p-org org h-org" href="https://coil.com">Coil Technologies Inc.</a>)
+    </dd>
         <dt>
-          <dfn data-lt="monetized|Monetization" id="dfn-monetized" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Monetization</dfn>:
-        </dt>
-        <dd>
-          Payments made by a user to a website, facilitated through a
-          <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-1">monetization provider</a>.
+                Former editors:
+              </dt><dd class="editor p-author h-card vcard">
+      <span class="p-name fn">Ben Sharafian</span> (<a class="p-org org h-org" href="https://coil.com">Coil Technologies Inc.</a>) -  Until <time datetime="2022-02-01">01 February 2022</time>
+    </dd><dd class="editor p-author h-card vcard">
+      <span class="p-name fn">Marcos Caceres</span> (<a class="p-org org h-org" href="https://w3.org/">W3C</a>) -  Until <time datetime="2022-03-23">23 March 2022</time>
+    </dd>
+        
+        <dt>Feedback:</dt><dd>
+          <a href="https://github.com/wicg/webmonetization/">GitHub wicg/webmonetization</a>
+          (<a href="https://github.com/wicg/webmonetization/pulls/">pull requests</a>,
+          <a href="https://github.com/wicg/webmonetization/issues/new/choose">new issue</a>,
+          <a href="https://github.com/wicg/webmonetization/issues/">open issues</a>)
         </dd>
-        <dt>
-          <dfn data-lt="provider|Monetization provider" id="dfn-provider" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Monetization provider</dfn>:
-        </dt>
-        <dd>
-          The party making payments on behalf of the user. A monetization
-          provider leverages the <cite><a data-matched-text="[[[Interledger]]]" href="https://interledger.org/rfcs/0027-interledger-protocol-4/">Interledger Protocol</a></cite> suite of protocols and
-          technologies (e.g., [<cite><a class="bibref" data-link-type="biblio" href="#bib-open payments" title="Open Payments">Open Payments</a></cite>] based on [<cite><a class="bibref" data-link-type="biblio" href="#bib-stream" title="STREAM">STREAM</a></cite>]) to provide
-          a high-level way to pay a <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-4">monetization receiver</a>.
-        </dd>
-        <dt>
-          <dfn data-plurals="monetization receivers" id="dfn-monetization-receiver" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Monetization receiver</dfn>:
-        </dt>
-        <dd>
-          The party receiving payments on behalf of the website, whose details
-          are provided by a <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-2">payment pointer</a>.
-        </dd>
-        <dt>
-          <dfn data-plurals="payment pointers" id="dfn-payment-pointer" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Payment Pointer</dfn>:
-        </dt>
-        <dd>
-          A <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> to an <a href="https://docs.openpayments.guide/#specification">Open
-          Payments API entry-point</a> (i.e., a JSON resource containing
-          details that facilitate payment to an account).
-        </dd>
-        <dt>
-          <dfn data-plurals="payment sessions" id="dfn-payment-session" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Payment session</dfn>
-        </dt>
-        <dd>
-          An session between a <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-2">monetization provider</a> and <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-5">monetization receiver</a> initiated by the <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://infra.spec.whatwg.org/#user-agent">user agent</a> at the <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-6">monetization receiver</a>. One or more payments can be initiated by the
-          <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-3">monetization provider</a> in a single session.
-        </dd>
+        
       </dl>
-    </section>
-    <section id="goals" class="informative"><div class="header-wrapper"><h2 id="x3-goals"><bdi class="secno">3. </bdi>
-        Goals
-      </h2><a class="self-link" href="#goals" aria-label="Permalink for Section 3."></a></div><p><em>This section is non-normative.</em></p>
       
-      <ul>
-        <li>Suitable for static HTML documents, without requiring backend
-        infrastructure.
-        </li>
-        <li>Doesn't require user interaction, but user retains control over
-        which sites they monetize and how much they spend.
-        </li>
-        <li>Developers have a way to associate payments with their users, in
-        order to provide a range of experiences.
-        </li>
-        <li>Users retain control of if, when, and how payments are made to the
-        site. For example, micropayments of a predetermined monetary value
-        could be "streamed" to the site over time. Alternatively, the user
-        could make one or many discreet "one-off" payment(s) of any arbitrary
-        monetary amount, even while micropayments are simultaneously being
-        streamed.
-        </li>
-      </ul>
-    </section>
-    <section id="link-type-monetization"><div class="header-wrapper"><h2 id="x4-link-type-monetization"><bdi class="secno">4. </bdi>
-        Link type "monetization"
-      </h2><a class="self-link" href="#link-type-monetization" aria-label="Permalink for Section 4."></a></div>
+      <p class="copyright">
+            <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>
+            ©
+            2023
+            
+            the Contributors to the Web Monetization
+            Specification, published by the
+            <a href="https://www.w3.org/groups/cg/wicg">Web Platform Incubator Community Group</a> under the
+            <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable
+                  <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a>
+                  is available.
+                
+          </p>
+      <hr title="Separator for header">
+    </div>
+      <section id="abstract" class="introductory"><h2>Abstract</h2>
+        <p>
+          Web Monetization allows websites to automatically receive payments from
+          users, facilitated by the user agent and a user's preferred
+          monetization provider.
+        </p>
+      </section>
+      <section id="sotd" class="introductory"><h2>Status of This Document</h2><p>
+        This specification was published by the
+        <a href="https://www.w3.org/groups/cg/wicg">Web Platform Incubator Community Group</a>. It is not a W3C Standard nor is it
+        on the W3C Standards Track.
+        
+              Please note that under the
+              <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>
+              there is a limited opt-out and other conditions apply.
+            
+        Learn more about
+        <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>.
+      </p>
+        <div class="warning" id="issue-container-generatedID"><div role="heading" class="warning-title marker" id="h-warning" aria-level="3"><span>Warning</span></div><div class="">
+          <p>
+            This specification is a work in progress within the community on the
+            best shape it should take. Please see the <a href="./docs/explainer">explainer</a> for more info.
+          </p>
+          <p>
+            The specification reflects the desired end-state of the Web
+            Monetization APIs as currently anticipated and agreed to between the
+            contributors. The specification is being prepared here, in this
+            format, to collect the input of the Web community and prepare the
+            work to ultimately follow the W3C standards track should it have the
+            necessary support to do so.
+          </p>
+          <p>
+            For the most accurate reflection of the APIs that have been
+            implemented by providers see the <a href="./docs/api">API
+            documentation</a>.
+          </p>
+        </div></div>
+      <p>
+      <a href="https://github.com/wicg/webmonetization/issues/">GitHub Issues</a> are preferred for
+            discussion of this specification.
+          
       
-      <div class="issue" id="issue-container-number-1"><div role="heading" class="issue-title marker" id="h-issue" aria-level="3"><span>Issue 1</span></div><aside class="">
-        <p>
-          This is a "monkey patch" for the [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>] specification: If accepted,
-          this will eventually be moved to HTML itself.
-        </p>
-      </aside></div>
-      <div class="note" role="note" id="issue-container-generatedID-0"><div role="heading" class="note-title marker" id="h-note" aria-level="3"><span>Note</span><span class="issue-label">: Multiple monetization links</span></div><aside class="">
-        <p>
-          Although a single HTML document can have multiple <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> elements
-          with the "monetization" link type, the user agent might restrict the
-          number of concurrent <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-1">payment sessions</a> it can simultaneously
-          support.
-        </p>
-      </aside></div>
-      <p>
-        The monetization keyword indicates a <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-3">payment pointer</a> used to
-        monetize the document.
-      </p>
-      <p>
-        The <code data-x="rel-monetization">monetization</code> keyword may be
-        used with <code>link</code> elements. This keyword creates an
-        <span data-x="external resource link">external resource link</span>.
-      </p>
-      <p>
-        The <code data-x="rel-monetization">monetization</code> keyword
-        indicates that some aspect of the document is monetized.
-      </p>
-      <div>
-        <p>
-          The default type for resources given by the <code data-x="rel-monetization">monetization</code> keyword is
-          <code>application/json</code>.
-        </p>
-        <p>
-          The appropriate times to <span data-x="fetch and process the linked resource">fetch and process</span> this
-          type of link is:
-        </p>
+    </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#abstract">Abstract</a></li><li class="tocline"><a class="tocxref" href="#sotd">Status of This Document</a></li><li class="tocline"><a class="tocxref" href="#usage-examples"><bdi class="secno">1. </bdi>
+          Usage examples
+        </a><ol class="toc"><li class="tocline"><a class="tocxref" href="#checking-if-web-monetization-is-supported"><bdi class="secno">1.1 </bdi>
+            Checking if Web Monetization is supported
+          </a></li><li class="tocline"><a class="tocxref" href="#monetizing-a-web-page"><bdi class="secno">1.2 </bdi>
+            Monetizing a web page
+          </a></li><li class="tocline"><a class="tocxref" href="#monetization-events"><bdi class="secno">1.3 </bdi>
+            Monetization events
+          </a></li><li class="tocline"><a class="tocxref" href="#verifying-a-payment"><bdi class="secno">1.4 </bdi>
+            Verifying a payment
+          </a></li><li class="tocline"><a class="tocxref" href="#monetizing-media"><bdi class="secno">1.5 </bdi>
+            Monetizing media
+          </a></li></ol></li><li class="tocline"><a class="tocxref" href="#model"><bdi class="secno">2. </bdi>
+          Model
+        </a></li><li class="tocline"><a class="tocxref" href="#goals"><bdi class="secno">3. </bdi>
+          Goals
+        </a></li><li class="tocline"><a class="tocxref" href="#link-type-monetization"><bdi class="secno">4. </bdi>
+          Link type "monetization"
+        </a></li><li class="tocline"><a class="tocxref" href="#onmonetization-event-handler"><bdi class="secno">5. </bdi>
+          <code>onmonetization</code> event handler
+        </a></li><li class="tocline"><a class="tocxref" href="#events"><bdi class="secno">6. </bdi>
+          monetization event
+        </a></li><li class="tocline"><a class="tocxref" href="#task-sources"><bdi class="secno">7. </bdi>
+          Task sources
+        </a></li><li class="tocline"><a class="tocxref" href="#monetizationcurrencyamount-interface"><bdi class="secno">8. </bdi>
+          <code>MonetizationCurrencyAmount</code> interface
+        </a><ol class="toc"><li class="tocline"><a class="tocxref" href="#currency-member"><bdi class="secno">8.1 </bdi>
+            <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="currency" data-dfn-for="MonetizationCurrencyAmount" data-type="DOMString" data-lt="currency" data-local-lt="MonetizationCurrencyAmount.currency"><code>currency</code></span> member
+          </a></li><li class="tocline"><a class="tocxref" href="#value-member"><bdi class="secno">8.2 </bdi>
+            <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="value" data-dfn-for="MonetizationCurrencyAmount" data-type="DOMString" data-lt="value" data-local-lt="MonetizationCurrencyAmount.value"><code>value</code></span> member
+          </a></li></ol></li><li class="tocline"><a class="tocxref" href="#monetizationevent-interface"><bdi class="secno">9. </bdi>
+          <code>MonetizationEvent</code> interface
+        </a><ol class="toc"><li class="tocline"><a class="tocxref" href="#amount-attribute-deprecated"><bdi class="secno">9.1 </bdi>
+            <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="amount" data-dfn-for="MonetizationEvent" data-type="DOMString" data-lt="amount" data-local-lt="MonetizationEvent.amount"><code>amount</code></span> attribute (deprecated)
+          </a></li><li class="tocline"><a class="tocxref" href="#assetcode-attribute-deprecated"><bdi class="secno">9.2 </bdi>
+            <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="assetCode" data-dfn-for="MonetizationEvent" data-type="DOMString" data-lt="assetCode" data-local-lt="MonetizationEvent.assetCode"><code>assetCode</code></span> attribute (deprecated)
+          </a></li><li class="tocline"><a class="tocxref" href="#assetscale-attribute-deprecated"><bdi class="secno">9.3 </bdi>
+            <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="assetScale" data-dfn-for="MonetizationEvent" data-type="octet" data-lt="assetScale" data-local-lt="MonetizationEvent.assetScale"><code>assetScale</code></span> attribute (deprecated)
+          </a></li><li class="tocline"><a class="tocxref" href="#amountsent-attribute"><bdi class="secno">9.4 </bdi>
+            <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="amountSent" data-dfn-for="MonetizationEvent" data-type="MonetizationCurrencyAmount" data-lt="amountSent" data-local-lt="MonetizationEvent.amountSent"><code>amountSent</code></span> attribute
+          </a></li><li class="tocline"><a class="tocxref" href="#receipt-attribute-deprecated"><bdi class="secno">9.5 </bdi>
+            <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="receipt" data-dfn-for="MonetizationEvent" data-type="DOMString" data-lt="receipt" data-local-lt="MonetizationEvent.receipt"><code>receipt</code></span> attribute (deprecated)
+          </a></li><li class="tocline"><a class="tocxref" href="#paymentpointer-attribute"><bdi class="secno">9.6 </bdi>
+            <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="paymentPointer" data-dfn-for="MonetizationEvent" data-type="USVString" data-lt="paymentPointer" data-local-lt="MonetizationEvent.paymentPointer"><code>paymentPointer</code></span> attribute
+          </a></li><li class="tocline"><a class="tocxref" href="#incomingpayment-attribute"><bdi class="secno">9.7 </bdi>
+            <span data-export="" data-dfn-type="attribute" data-idl="attribute" data-title="incomingPayment" data-dfn-for="MonetizationEvent" data-type="USVString" data-lt="incomingPayment" data-local-lt="MonetizationEvent.incomingPayment"><code>incomingPayment</code></span> attribute
+          </a></li></ol></li><li class="tocline"><a class="tocxref" href="#permissions-policy"><bdi class="secno">10. </bdi>
+          Permissions Policy integration
+        </a></li><li class="tocline"><a class="tocxref" href="#content-security-policy"><bdi class="secno">11. </bdi>
+          Content Security Policy
+        </a><ol class="toc"><li class="tocline"><a class="tocxref" href="#monetization-src-directive"><bdi class="secno">11.1 </bdi>
+            <span class="export" data-export="">monetization-src</span> directive
+          </a><ol class="toc"><li class="tocline"><a class="tocxref" href="#monetization-src-pre-request-check"><bdi class="secno">11.1.1 </bdi>
+              <code>monetization-src</code> Pre-request check
+            </a></li><li class="tocline"><a class="tocxref" href="#monetization-src-post-request-check"><bdi class="secno">11.1.2 </bdi>
+              <code>monetization-src</code> Post-request check
+            </a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#security-considerations"><bdi class="secno">12. </bdi>
+          Security considerations
+        </a></li><li class="tocline"><a class="tocxref" href="#privacy-considerations"><bdi class="secno">13. </bdi>
+          Privacy considerations
+        </a></li><li class="tocline"><a class="tocxref" href="#relation-to-other-technologies"><bdi class="secno">14. </bdi>
+          Relation to Web Payments
+        </a></li><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">A. </bdi>Conformance</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">B. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">B.1 </bdi>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">B.2 </bdi>Informative references</a></li></ol></li></ol></nav>
+      <section class="informative" id="usage-examples"><div class="header-wrapper"><h2 id="x1-usage-examples"><bdi class="secno">1. </bdi>
+          Usage examples
+        </h2><a class="self-link" href="#usage-examples" aria-label="Permalink for Section 1."></a></div><p><em>This section is non-normative.</em></p>
+        
+        <section id="checking-if-web-monetization-is-supported"><div class="header-wrapper"><h3 id="x1-1-checking-if-web-monetization-is-supported"><bdi class="secno">1.1 </bdi>
+            Checking if Web Monetization is supported
+          </h3><a class="self-link" href="#checking-if-web-monetization-is-supported" aria-label="Permalink for Section 1.1"></a></div>
+          
+          <p>
+            There are multiple ways to check if Web Monetization is supported.
+            One way is to call <a data-link-type="idl" data-lt="supports()" data-type="method" href="https://dom.spec.whatwg.org/#dom-domtokenlist-supports"><code>supports</code></a><code>()</code> on a <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code>
+            element's <a data-link-type="idl" data-type="attribute" href="https://html.spec.whatwg.org/multipage/semantics.html#dom-link-rellist"><code>relList</code></a> passing the <code>"monetization"</code>
+            keyword. Alternatively, you can check if either the
+            <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-1"><code>MonetizationEvent</code></a> interface or the "<code>onmonetization</code>" <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">event handler IDL attribute</a> exist on the <a data-link-type="idl" data-lt="Window" data-type="interface" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window"><code>Window</code></a> object.
+          </p>
+          <aside class="example" id="example-1"><div class="marker">
+      <a class="self-link" href="#example-1">Example<bdi> 1</bdi></a>
+    </div>
+            <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">link</span> <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.com/monetization.js"</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
+    <span class="hljs-comment">// Checking via DOMTokenList</span>
+    <span class="hljs-keyword">const</span> link = <span class="hljs-built_in">document</span>.querySelector(<span class="hljs-string">'link[rel="monetization"]'</span>) ||
+      <span class="hljs-built_in">document</span>.createElement(<span class="hljs-string">"link"</span>);
+    <span class="hljs-keyword">if</span> (link.relList.supports(<span class="hljs-string">"monetization"</span>)) {
+      <span class="hljs-built_in">console</span>.log(<span class="hljs-string">"Web Monetization is supported."</span>);
+    }
+  
+    <span class="hljs-comment">// Checking global scope for MonetizationEvent</span>
+    <span class="hljs-keyword">if</span> (<span class="hljs-built_in">window</span>.MonetizationEvent) {
+      <span class="hljs-built_in">console</span>.log(<span class="hljs-string">"Web Monetization is supported."</span>);
+    }
+  
+    <span class="hljs-comment">// Checking if it's a global event handler</span>
+    <span class="hljs-keyword">if</span> (<span class="hljs-built_in">window</span>.hasOwnProperty(<span class="hljs-string">"onmonetization"</span>)) {
+      <span class="hljs-built_in">console</span>.log(<span class="hljs-string">"Web Monetization is supported."</span>);
+    }
+  </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></code></pre>
+          </aside>
+        </section>
+        <section id="monetizing-a-web-page"><div class="header-wrapper"><h3 id="x1-2-monetizing-a-web-page"><bdi class="secno">1.2 </bdi>
+            Monetizing a web page
+          </h3><a class="self-link" href="#monetizing-a-web-page" aria-label="Permalink for Section 1.2"></a></div>
+          
+          <aside class="example" id="example-2"><div class="marker">
+      <a class="self-link" href="#example-2">Example<bdi> 2</bdi></a>
+    </div>
+            <pre aria-busy="false"><code class="hljs html"><span class="hljs-meta">&lt;!DOCTYPE <span class="hljs-meta-keyword">html</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">html</span> <span class="hljs-attr">lang</span>=<span class="hljs-string">"en"</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">meta</span> <span class="hljs-attr">charset</span>=<span class="hljs-string">"utf-8"</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">title</span>&gt;</span>My Blog<span class="hljs-tag">&lt;/<span class="hljs-name">title</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">link</span>
+    <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span>
+    <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.com/pay"</span>
+    <span class="hljs-attr">onmonetization</span>=<span class="hljs-string">"sayThanks(this)"</span>&gt;</span>
+  
+  <span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
+    <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">sayThanks</span>(<span class="hljs-params">monetizedLink</span>) </span>{
+      <span class="hljs-comment">// Do something here</span>
+    }
+  </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></code></pre>
+          </aside>
+        </section>
+        <section id="monetization-events"><div class="header-wrapper"><h3 id="x1-3-monetization-events"><bdi class="secno">1.3 </bdi>
+            Monetization events
+          </h3><a class="self-link" href="#monetization-events" aria-label="Permalink for Section 1.3"></a></div>
+          
+          <p>
+            The <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-2"><code>MonetizationEvent</code></a> DOM events provide information such as the
+            amount sent, the currency of the payment, and a link to the incoming
+            payment at the <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-1">monetization receiver</a> which can be used to verify
+            the receipt of payment. As in the previous example above, these
+            events are dispatched to <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> elements and bubble up the DOM
+            tree.
+          </p>
+          <p>
+            To listen for <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-3"><code>MonetizationEvent</code></a> events, an <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-listener">event listener</a>
+            needs to be added to the relevant <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element (or to one of its
+            ancestors) via JavaScript:
+          </p>
+          <aside class="example" id="example-3"><div class="marker">
+      <a class="self-link" href="#example-3">Example<bdi> 3</bdi></a>
+    </div>
+            <pre aria-busy="false"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">link</span> <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.com/pay"</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
+    <span class="hljs-keyword">const</span> link = <span class="hljs-built_in">document</span>.querySelector(<span class="hljs-string">'link[rel="monetization"]'</span>);
+    link.addEventListener(<span class="hljs-string">"monetization"</span>, <span class="hljs-function"><span class="hljs-params">event</span> =&gt;</span> {
+      <span class="hljs-comment">// See how much was sent and in what currency</span>
+      <span class="hljs-keyword">const</span> { <span class="hljs-attr">amountSent</span> : { value, currency }} = event;
+      <span class="hljs-built_in">console</span>.log(<span class="hljs-string">`Browser sent <span class="hljs-subst">${currency}</span> <span class="hljs-subst">${value}</span>.`</span>);
+  
+      <span class="hljs-comment">// Use the incoming payment URL to verify the payment at the receiver.</span>
+      verifyPayment(event);
+    });
+  </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></code></pre>
+          </aside>
+        </section>
+        <section id="verifying-a-payment"><div class="header-wrapper"><h3 id="x1-4-verifying-a-payment"><bdi class="secno">1.4 </bdi>
+            Verifying a payment
+          </h3><a class="self-link" href="#verifying-a-payment" aria-label="Permalink for Section 1.4"></a></div>
+          
+          <p>
+            The <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-4"><code>MonetizationEvent</code></a>'s <a data-link-type="idl" href="#dom-monetizationevent-incomingpayment" class="internalDFN" id="ref-for-dom-monetizationevent-incomingpayment-1"><code>incomingPayment</code></a>
+            attribute is a URL that can be used to verify the payment at the
+            <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-2">monetization receiver</a>.
+          </p>
+          <p>
+            In most cases requests to the <a data-link-type="idl" href="#dom-monetizationevent-incomingpayment" class="internalDFN" id="ref-for-dom-monetizationevent-incomingpayment-2"><code>incomingPayment</code></a>
+            URL will need to be authenticated as they fetch sensitive details
+            such as the <code>receivedAmount</code>. The specifics of this authentication
+            are agreed by the website and the <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-3">monetization receiver</a> when
+            setting up the receiving account.
+          </p>
+          <p>
+            Below is a hypothetical naive verification method that will make a
+            request to the <a data-link-type="idl" href="#dom-monetizationevent-incomingpayment" class="internalDFN" id="ref-for-dom-monetizationevent-incomingpayment-3"><code>incomingPayment</code></a> URL and simply
+            return the results. For simplicity it has no logic for authenticating
+            the request.
+          </p>
+          <p>
+            A more sophisticated implementation should track the <code>receivedAmount</code>
+            property and ensure it is increasing after each <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-5"><code>MonetizationEvent</code></a>
+            to verify that a new payment has been received.
+          </p>
+          <aside class="example" id="example-4"><div class="marker">
+      <a class="self-link" href="#example-4">Example<bdi> 4</bdi></a>
+    </div>
+            <pre class="JS" aria-busy="false"><code class="hljs js"><span class="hljs-comment">/** <span class="hljs-doctag">@type <span class="hljs-type">{MonetizationEvent}</span> </span>event */</span>
+  <span class="hljs-keyword">async</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">verifyPayment</span>(<span class="hljs-params">event</span>) </span>{
+    <span class="hljs-comment">// Legacy receivers don't support returning incoming payment URLs</span>
+    <span class="hljs-keyword">if</span>(!event.incomingPayment){
+      <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">'No incoming payment URL'</span>)
+    }
+  
+    <span class="hljs-comment">// Poll the incoming payment to check the amount received</span>
+    <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> fetch(event.incomingPayment, {
+      <span class="hljs-attr">credentials</span>: <span class="hljs-string">'same-origin'</span>,
+      <span class="hljs-attr">mode</span>: <span class="hljs-string">'same-origin'</span>,
+      <span class="hljs-attr">cache</span>: <span class="hljs-string">'no-cache'</span>,
+      <span class="hljs-attr">headers</span>: {
+        <span class="hljs-string">'Content-Type'</span>: <span class="hljs-string">'application/json'</span>
+      }
+    });
+  
+    <span class="hljs-keyword">if</span> (response.ok) {
+      <span class="hljs-comment">// The incoming payment was fetched successfully</span>
+      <span class="hljs-keyword">const</span> { receivedAmount } = <span class="hljs-built_in">JSON</span>.parse(<span class="hljs-keyword">await</span> response.json())
+      <span class="hljs-keyword">const</span> { amount, assetCode, assetScale } = receivedAmount;
+      <span class="hljs-built_in">console</span>.log(<span class="hljs-string">`Received <span class="hljs-subst">${assetCode}</span><span class="hljs-subst">${amount / (<span class="hljs-number">10</span> ** assetScale)}</span>.`</span>);
+      <span class="hljs-keyword">return</span> receivedAmount;
+    }
+  }</code></pre>
+          </aside>
+        </section>
+        <section id="monetizing-media"><div class="header-wrapper"><h3 id="x1-5-monetizing-media"><bdi class="secno">1.5 </bdi>
+            Monetizing media
+          </h3><a class="self-link" href="#monetizing-media" aria-label="Permalink for Section 1.5"></a></div>
+          
+          <p>
+            The following example shows how to monetize various types of media
+            using different <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-1">payment pointers</a>.
+          </p>
+          <aside class="example" id="example-5"><div class="marker">
+      <a class="self-link" href="#example-5">Example<bdi> 5</bdi></a>
+    </div>
+            <pre aria-busy="false"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">video</span> <span class="hljs-attr">src</span>=<span class="hljs-string">"myvideo"</span> <span class="hljs-attr">onmonetization</span>=<span class="hljs-string">"sayThanks(this)"</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">link</span> <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.com/video/pay"</span>&gt;</span>
+  <span class="hljs-tag">&lt;/<span class="hljs-name">video</span>&gt;</span>
+  
+  <span class="hljs-tag">&lt;<span class="hljs-name">audio</span> <span class="hljs-attr">src</span>=<span class="hljs-string">"music.mp3"</span> <span class="hljs-attr">onmonetization</span>=<span class="hljs-string">"sayThanks(this)"</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">link</span> <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.com/audio/pay"</span>&gt;</span>
+  <span class="hljs-tag">&lt;/<span class="hljs-name">audio</span>&gt;</span>
+  
+  <span class="hljs-tag">&lt;<span class="hljs-name">picture</span> <span class="hljs-attr">srcset</span>=<span class="hljs-string">"cat.jpeg"</span> <span class="hljs-attr">onmonetization</span>=<span class="hljs-string">"sayThanks(this)"</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">link</span> <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.com/images/pay"</span>&gt;</span>
+  <span class="hljs-tag">&lt;/<span class="hljs-name">picture</span>&gt;</span></code></pre>
+          </aside>
+        </section>
+      </section>
+      <section id="model"><div class="header-wrapper"><h2 id="x2-model"><bdi class="secno">2. </bdi>
+          Model
+        </h2><a class="self-link" href="#model" aria-label="Permalink for Section 2."></a></div>
+        
+        <dl>
+          <dt>
+            <dfn data-lt="monetized|Monetization" id="dfn-monetized" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Monetization</dfn>:
+          </dt>
+          <dd>
+            Payments made by a user to a website, facilitated through a
+            <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-1">monetization provider</a>.
+          </dd>
+          <dt>
+            <dfn data-lt="provider|Monetization provider" id="dfn-provider" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Monetization provider</dfn>:
+          </dt>
+          <dd>
+            The party making payments on behalf of the user. A monetization
+            provider leverages the <cite><a data-matched-text="[[[Interledger]]]" href="https://interledger.org/rfcs/0027-interledger-protocol-4/">Interledger Protocol</a></cite> suite of protocols and
+            technologies (e.g., [<cite><a class="bibref" data-link-type="biblio" href="#bib-open payments" title="Open Payments">Open Payments</a></cite>] based on [<cite><a class="bibref" data-link-type="biblio" href="#bib-stream" title="STREAM">STREAM</a></cite>]) to provide
+            a high-level way to pay a <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-4">monetization receiver</a>.
+          </dd>
+          <dt>
+            <dfn data-plurals="monetization receivers" id="dfn-monetization-receiver" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Monetization receiver</dfn>:
+          </dt>
+          <dd>
+            The party receiving payments on behalf of the website, whose details
+            are provided by a <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-2">payment pointer</a>.
+          </dd>
+          <dt>
+            <dfn data-plurals="payment pointers" id="dfn-payment-pointer" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Payment Pointer</dfn>:
+          </dt>
+          <dd>
+            A <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> to an <a href="https://docs.openpayments.guide/#specification">Open
+            Payments API entry-point</a> (i.e., a JSON resource containing
+            details that facilitate payment to an account).
+          </dd>
+          <dt>
+            <dfn data-plurals="payment sessions" id="dfn-payment-session" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Payment session</dfn>
+          </dt>
+          <dd>
+            An session between a <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-2">monetization provider</a> and <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-5">monetization receiver</a> initiated by the <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://infra.spec.whatwg.org/#user-agent">user agent</a> at the <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-6">monetization receiver</a>. One or more payments can be initiated by the
+            <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-3">monetization provider</a> in a single session.
+          </dd>
+        </dl>
+      </section>
+      <section id="goals" class="informative"><div class="header-wrapper"><h2 id="x3-goals"><bdi class="secno">3. </bdi>
+          Goals
+        </h2><a class="self-link" href="#goals" aria-label="Permalink for Section 3."></a></div><p><em>This section is non-normative.</em></p>
+        
         <ul>
-          <li>
-            <p>
-              When the <span>external resource link</span> is created on a
-              <code>link</code> element that is already <span>browsing-context
-              connected</span>.
-            </p>
+          <li>Suitable for static HTML documents, without requiring backend
+          infrastructure.
           </li>
-          <li>
-            <p>
-              When the <span>external resource link</span>'s <code>link</code>
-              element <span>becomes browsing-context connected</span>.
-            </p>
+          <li>Doesn't require user interaction, but user retains control over
+          which sites they monetize and how much they spend.
           </li>
-          <li>
-            <p>
-              When the <code data-x="attr-link-href">href</code> attribute of
-              the <code>link</code> element of an <span>external resource
-              link</span> that is already <span>browsing-context
-              connected</span> is changed.
-            </p>
+          <li>Developers have a way to associate payments with their users, in
+          order to provide a range of experiences.
           </li>
-          <li>
-            <p>
-              When the <code data-x="attr-link-disabled">disabled</code>
-              attribute of the <code>link</code> element of an <span>external
-              resource link</span> that is already <span>browsing-context
-              connected</span> is set, changed, or removed.
-            </p>
-          </li>
-          <li>
-            <p>
-              When the <code data-x="attr-link-crossorigin">crossorigin</code>
-              attribute of the <code>link</code> element of an <span data-x="external resource link">external resource link</span> that is
-              already <span>browsing-context connected</span> is set, changed,
-              or removed.
-            </p>
-          </li>
-          <li>
-            <p>
-              When the <code data-x="attr-link-type">type</code> attribute of
-              the <code>link</code> element of an <span>external resource
-              link</span> that is already <span>browsing-context
-              connected</span> is set or changed to a value that does not or no
-              longer matches the <span data-x="Content-Type">Content-Type
-              metadata</span> of the previous obtained external resource, if
-              any.
-            </p>
-          </li>
-          <li>
-            <p>
-              When the <code data-x="attr-link-type">type</code> attribute of
-              the <code>link</code> element of an <span>external resource
-              link</span> that is already <span>browsing-context
-              connected</span>, but was previously not obtained due to the
-              <code data-x="attr-link-type">type</code> attribute specifying an
-              unsupported type, is set, removed, or changed.
-            </p>
+          <li>Users retain control of if, when, and how payments are made to the
+          site. For example, micropayments of a predetermined monetary value
+          could be "streamed" to the site over time. Alternatively, the user
+          could make one or many discreet "one-off" payment(s) of any arbitrary
+          monetary amount, even while micropayments are simultaneously being
+          streamed.
           </li>
         </ul>
+      </section>
+      <section id="link-type-monetization"><div class="header-wrapper"><h2 id="x4-link-type-monetization"><bdi class="secno">4. </bdi>
+          Link type "monetization"
+        </h2><a class="self-link" href="#link-type-monetization" aria-label="Permalink for Section 4."></a></div>
+        
+        <div class="issue" id="issue-container-number-1"><div role="heading" class="issue-title marker" id="h-issue" aria-level="3"><span>Issue 1</span></div><aside class="">
+          <p>
+            This is a "monkey patch" for the [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>] specification: If accepted,
+            this will eventually be moved to HTML itself.
+          </p>
+        </aside></div>
+        <div class="note" role="note" id="issue-container-generatedID-0"><div role="heading" class="note-title marker" id="h-note" aria-level="3"><span>Note</span><span class="issue-label">: Multiple monetization links</span></div><aside class="">
+          <p>
+            Although a single HTML document can have multiple <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> elements
+            with the "monetization" link type, the user agent might restrict the
+            number of concurrent <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-1">payment sessions</a> it can simultaneously
+            support.
+          </p>
+        </aside></div>
         <p>
-          A user agent <em class="rfc2119">MUST NOT</em> <span>delay the load event</span> for this link
-          type.
+          The monetization keyword indicates a <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-3">payment pointer</a> used to
+          monetize the document.
         </p>
         <p>
-          The <span>linked resource fetch setup steps</span> for this type of
-          linked resource, given a <code>link</code> element <var>element</var>
-          and <span data-x="concept-request">request</span> <var>request</var>,
-          are:
+          The <code data-x="rel-monetization">monetization</code> keyword may be
+          used with <code>link</code> elements. This keyword creates an
+          <span data-x="external resource link">external resource link</span>.
         </p>
-        <ol>
-          <li>
-            
-            <p>
-              If <var>element</var> <span>cannot navigate</span>, then return
-              false.
-            </p>
-          </li>
-          <li>
-            <p>
-              If <var>element</var>'s <span>node document</span> is not
-              <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">allowed to use</a> the "monetization" feature, return false.
-            </p>
-          </li>
-          <li>
-            <p>
-              Let <var>context</var> be <var>element</var>'s <span>node
-              document</span>'s <span data-x="concept-document-bc">browsing
-              context</span>.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set <var>request</var>'s <span data-x="concept-request-initiator">initiator</span> to "<code>document</code>".
-            </p>
-          </li>
-          <li>
-            <p>
-              Set <var>request</var>'s <span data-x="concept-request-destination">destination</span> to
-              "<code data-x="">monetization</code>".
-            </p>
-          </li>
-          <li>
-            <p>
-              Set <var>request</var>'s <span data-x="concept-request-mode">mode</span> to "<code data-x="">cors</code>".
-            </p>
-          </li>
-          <li>
-            <p>
-              Set <var>request</var>'s <span data-x="concept-request-credentials-mode">credentials mode</span> to the
-              <span>CORS settings attribute credentials mode</span> for
-              <var>element</var>'s <code data-x="attr-link-crossorigin">crossorigin</code> content attribute.
-            </p>
-          </li>
-          <li>
-            <p>
-              Return true.
-            </p>
-          </li>
-        </ol>
         <p>
-          To <span data-x="process the linked resource">process this type of
-          linked resource</span> given a <code>link</code> element
-          <var>element</var>, boolean <var>success</var>, and <span data-x="concept-response">response</span> <var>response</var>:
+          The <code data-x="rel-monetization">monetization</code> keyword
+          indicates that some aspect of the document is monetized.
         </p>
-        <ol>
-          <li>
-            <p>
-              If <var>response</var>'s status is not an OK status, the set <var>success</var> to
-              false.
-            </p>
+        <div>
+          <p>
+            The default type for resources given by the <code data-x="rel-monetization">monetization</code> keyword is
+            <code>application/json</code>.
+          </p>
+          <p>
+            The appropriate times to <span data-x="fetch and process the linked resource">fetch and process</span> this
+            type of link is:
+          </p>
+          <ul>
+            <li>
+              <p>
+                When the <span>external resource link</span> is created on a
+                <code>link</code> element that is already <span>browsing-context
+                connected</span>.
+              </p>
+            </li>
+            <li>
+              <p>
+                When the <span>external resource link</span>'s <code>link</code>
+                element <span>becomes browsing-context connected</span>.
+              </p>
+            </li>
+            <li>
+              <p>
+                When the <code data-x="attr-link-href">href</code> attribute of
+                the <code>link</code> element of an <span>external resource
+                link</span> that is already <span>browsing-context
+                connected</span> is changed.
+              </p>
+            </li>
+            <li>
+              <p>
+                When the <code data-x="attr-link-disabled">disabled</code>
+                attribute of the <code>link</code> element of an <span>external
+                resource link</span> that is already <span>browsing-context
+                connected</span> is set, changed, or removed.
+              </p>
+            </li>
+            <li>
+              <p>
+                When the <code data-x="attr-link-crossorigin">crossorigin</code>
+                attribute of the <code>link</code> element of an <span data-x="external resource link">external resource link</span> that is
+                already <span>browsing-context connected</span> is set, changed,
+                or removed.
+              </p>
+            </li>
+            <li>
+              <p>
+                When the <code data-x="attr-link-type">type</code> attribute of
+                the <code>link</code> element of an <span>external resource
+                link</span> that is already <span>browsing-context
+                connected</span> is set or changed to a value that does not or no
+                longer matches the <span data-x="Content-Type">Content-Type
+                metadata</span> of the previous obtained external resource, if
+                any.
+              </p>
+            </li>
+            <li>
+              <p>
+                When the <code data-x="attr-link-type">type</code> attribute of
+                the <code>link</code> element of an <span>external resource
+                link</span> that is already <span>browsing-context
+                connected</span>, but was previously not obtained due to the
+                <code data-x="attr-link-type">type</code> attribute specifying an
+                unsupported type, is set, removed, or changed.
+              </p>
+            </li>
+          </ul>
+          <p>
+            A user agent <em class="rfc2119">MUST NOT</em> <span>delay the load event</span> for this link
+            type.
+          </p>
+          <p>
+            The <span>linked resource fetch setup steps</span> for this type of
+            linked resource, given a <code>link</code> element <var>element</var>
+            and <span data-x="concept-request">request</span> <var>request</var>,
+            are:
+          </p>
+          <ol>
+            <li>
+              
+              <p>
+                If <var>element</var> <span>cannot navigate</span>, then return
+                false.
+              </p>
+            </li>
+            <li>
+              <p>
+                If <var>element</var>'s <span>node document</span> is not
+                <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">allowed to use</a> the "monetization" feature, return false.
+              </p>
+            </li>
+            <li>
+              <p>
+                Let <var>context</var> be <var>element</var>'s <span>node
+                document</span>'s <span data-x="concept-document-bc">browsing
+                context</span>.
+              </p>
+            </li>
+            <li>
+              <p>
+                Set <var>request</var>'s <span data-x="concept-request-initiator">initiator</span> to "<code>document</code>".
+              </p>
+            </li>
+            <li>
+              <p>
+                Set <var>request</var>'s <span data-x="concept-request-destination">destination</span> to
+                "<code data-x="">monetization</code>".
+              </p>
+            </li>
+            <li>
+              <p>
+                Set <var>request</var>'s <span data-x="concept-request-mode">mode</span> to "<code data-x="">cors</code>".
+              </p>
+            </li>
+            <li>
+              <p>
+                Set <var>request</var>'s <span data-x="concept-request-credentials-mode">credentials mode</span> to the
+                <span>CORS settings attribute credentials mode</span> for
+                <var>element</var>'s <code data-x="attr-link-crossorigin">crossorigin</code> content attribute.
+              </p>
+            </li>
+            <li>
+              <p>
+                Return true.
+              </p>
+            </li>
+          </ol>
+          <p>
+            To <span data-x="process the linked resource">process this type of
+            linked resource</span> given a <code>link</code> element
+            <var>element</var>, boolean <var>success</var>, and <span data-x="concept-response">response</span> <var>response</var>:
+          </p>
+          <ol>
+            <li>
+              <p>
+                If <var>response</var>'s status is not an OK status, the set <var>success</var> to
+                false.
+              </p>
+            </li>
+            <li>
+              <p>
+                Otherwise, if <var>response</var>'s <span data-x="Content-Type">Content-Type metadata</span> is not a
+                <code>application/json</code>, then set <var>success</var> to
+                false.
+              </p>
+            </li>
+            <li>Let <var>json</var> be the result of <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://infra.spec.whatwg.org/#parse-json-bytes-to-an-infra-value">parse JSON bytes to an Infra value</a> passing <var>response</var>'s <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body">body</a>.
+            </li>
+            <li>If <var>json</var> is an exception, then set <var>success</var> to false.
+            </li>
+            <li>
+              <p>
+                If the user agent has exhausted the number of allowed <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-2">payment sessions</a>, set <var>success</var> to false.
+              </p>
+            </li>
+            <li>Otherwise, establish a new <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-3">payment session</a>.
+            </li>
+            <li><a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-an-element-task">Queue an element task</a> on the <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source">networking task source</a> given
+            <var>element</var> and the following steps:
+              <ol>
+                <li>If <var>success</var> is true, <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>"load"</code> at
+                <var>element</var>.
+                </li>
+                <li>Otherwise, <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>"error"</code> at <var>element</var>.
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </div>
+        <p>
+          If a "monetization" <code>link</code> <span>becomes browsing-context
+          disconnected</span>, a user agent <em class="rfc2119">MUST</em> stop the <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-4">payment session</a>.
+        </p>
+      </section>
+      <section id="onmonetization-event-handler"><div class="header-wrapper"><h2 id="x5-onmonetization-event-handler"><bdi class="secno">5. </bdi>
+          <code>onmonetization</code> event handler
+        </h2><a class="self-link" href="#onmonetization-event-handler" aria-label="Permalink for Section 5."></a></div>
+        
+        <p>
+          The <code>onmonetization</code> event handler is an <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes">event handler content attribute</a> that can be applied to any <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://dom.spec.whatwg.org/#concept-element">element</a>. The user agent uses
+          it to notify that some <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> has been <a data-link-type="dfn|abstract-op" href="#dfn-monetized" class="internalDFN" id="ref-for-dfn-monetized-1">monetized</a>.
+        </p>
+      </section>
+      <section id="events"><div class="header-wrapper"><h2 id="x6-monetization-event"><bdi class="secno">6. </bdi>
+          monetization event
+        </h2><a class="self-link" href="#events" aria-label="Permalink for Section 6."></a></div>
+        
+        <p>
+          When the <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-5">payment session</a> has sent a <var>payment</var> with a non-zero
+          amount, perform the following steps:
+        </p>
+        <ol class="algorithm">
+          <li>Let <var data-type="HTMLLinkElement">target</var> be the <a data-link-type="idl" data-lt="HTMLLinkElement" data-type="interface" href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement"><code>HTMLLinkElement</code></a> associated
+          with the <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-6">payment session</a>.
           </li>
-          <li>
-            <p>
-              Otherwise, if <var>response</var>'s <span data-x="Content-Type">Content-Type metadata</span> is not a
-              <code>application/json</code>, then set <var>success</var> to
-              false.
-            </p>
+          <li>If <var data-type="HTMLLinkElement">target</var> is <code>null</code>, then return.
           </li>
-          <li>Let <var>json</var> be the result of <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://infra.spec.whatwg.org/#parse-json-bytes-to-an-infra-value">parse JSON bytes to an Infra value</a> passing <var>response</var>'s <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body">body</a>.
+          <li>Let <var data-type="MonetizationEventInit">eventInitDict</var> be a
+          <a data-link-type="idl" data-lt="MonetizationEventInit" href="#dom-monetizationeventinit" class="internalDFN" id="ref-for-dom-monetizationeventinit-1"><code>MonetizationEventInit</code></a> dictionary, whose members are initialized to
+          match <var>payment</var>'s details.
           </li>
-          <li>If <var>json</var> is an exception, then set <var>success</var> to false.
+          <li>Let <var data-type="MonetizationEvent">event</var> be a newly constructed
+          <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-6"><code>MonetizationEvent</code></a> initialized with <var data-type="MonetizationEventInit">eventInitDict</var>.
           </li>
-          <li>
-            <p>
-              If the user agent has exhausted the number of allowed <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-2">payment sessions</a>, set <var>success</var> to false.
-            </p>
-          </li>
-          <li>Otherwise, establish a new <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-3">payment session</a>.
-          </li>
-          <li><a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-an-element-task">Queue an element task</a> on the <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source">networking task source</a> given
-          <var>element</var> and the following steps:
+          <li><a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> on the <a data-link-type="dfn|abstract-op" href="#dfn-monetization-task-source" class="internalDFN" id="ref-for-dfn-monetization-task-source-1">monetization task source</a> to perform the
+          following steps:
             <ol>
-              <li>If <var>success</var> is true, <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>"load"</code> at
-              <var>element</var>.
+              <li>If <var data-type="HTMLLinkElement">target</var> is not connected, return.
               </li>
-              <li>Otherwise, <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>"error"</code> at <var>element</var>.
+              <li><a data-link-type="dfn|abstract-op" data-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <code>"monetization"</code> at <var data-type="HTMLLinkElement">target</var>, with
+              <a data-link-type="idl" data-type="attribute" href="https://dom.spec.whatwg.org/#dom-event-bubbles"><code>bubbles</code></a> initialized to true.
               </li>
             </ol>
           </li>
         </ol>
-      </div>
-      <p>
-        If a "monetization" <code>link</code> <span>becomes browsing-context
-        disconnected</span>, a user agent <em class="rfc2119">MUST</em> stop the <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-4">payment session</a>.
-      </p>
-    </section>
-    <section id="onmonetization-event-handler"><div class="header-wrapper"><h2 id="x5-onmonetization-event-handler"><bdi class="secno">5. </bdi>
-        <code>onmonetization</code> event handler
-      </h2><a class="self-link" href="#onmonetization-event-handler" aria-label="Permalink for Section 5."></a></div>
-      
-      <p>
-        The <code>onmonetization</code> event handler is an <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes">event handler content attribute</a> that can be applied to any <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://dom.spec.whatwg.org/#concept-element">element</a>. The user agent uses
-        it to notify that some <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> has been <a data-link-type="dfn|abstract-op" href="#dfn-monetized" class="internalDFN" id="ref-for-dfn-monetized-1">monetized</a>.
-      </p>
-    </section>
-    <section id="events"><div class="header-wrapper"><h2 id="x6-monetization-event"><bdi class="secno">6. </bdi>
-        monetization event
-      </h2><a class="self-link" href="#events" aria-label="Permalink for Section 6."></a></div>
-      
-      <p>
-        When the <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-5">payment session</a> has sent a <var>payment</var> with a non-zero
-        amount, perform the following steps:
-      </p>
-      <ol class="algorithm">
-        <li>Let <var data-type="HTMLLinkElement">target</var> be the <a data-link-type="idl" data-lt="HTMLLinkElement" data-type="interface" href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement"><code>HTMLLinkElement</code></a> associated
-        with the <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-6">payment session</a>.
-        </li>
-        <li>If <var data-type="HTMLLinkElement">target</var> is <code>null</code>, then return.
-        </li>
-        <li>Let <var data-type="MonetizationEventInit">eventInitDict</var> be a
-        <a data-link-type="idl" data-lt="MonetizationEventInit" href="#dom-monetizationeventinit" class="internalDFN" id="ref-for-dom-monetizationeventinit-1"><code>MonetizationEventInit</code></a> dictionary, whose members are initialized to
-        match <var>payment</var>'s details.
-        </li>
-        <li>Let <var data-type="MonetizationEvent">event</var> be a newly constructed
-        <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-6"><code>MonetizationEvent</code></a> initialized with <var data-type="MonetizationEventInit">eventInitDict</var>.
-        </li>
-        <li><a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> on the <a data-link-type="dfn|abstract-op" href="#dfn-monetization-task-source" class="internalDFN" id="ref-for-dfn-monetization-task-source-1">monetization task source</a> to perform the
-        following steps:
-          <ol>
-            <li>If <var data-type="HTMLLinkElement">target</var> is not connected, return.
-            </li>
-            <li><a data-link-type="dfn|abstract-op" data-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <code>"monetization"</code> at <var data-type="HTMLLinkElement">target</var>, with
-            <a data-link-type="idl" data-type="attribute" href="https://dom.spec.whatwg.org/#dom-event-bubbles"><code>bubbles</code></a> initialized to true.
-            </li>
-          </ol>
-        </li>
-      </ol>
-    </section>
-    <section id="task-sources"><div class="header-wrapper"><h2 id="x7-task-sources"><bdi class="secno">7. </bdi>
-        Task sources
-      </h2><a class="self-link" href="#task-sources" aria-label="Permalink for Section 7."></a></div>
-      
-      <p>
-        The following <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is defined by this specifications.
-      </p>
-      <dl>
-        <dt>
-          The <dfn id="dfn-monetization-task-source" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">monetization task source</dfn>
-        </dt>
-        <dd>
-          Used by this specification to queue up non-blocking
-          <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-7"><code>MonetizationEvent</code></a>s.
-        </dd>
-      </dl>
-    </section>
-    <section data-dfn-for="MonetizationCurrencyAmount" id="monetizationcurrencyamount-interface"><div class="header-wrapper"><h2 id="x8-monetizationcurrencyamount-interface"><bdi class="secno">8. </bdi>
-        <code>MonetizationCurrencyAmount</code> interface
-      </h2><a class="self-link" href="#monetizationcurrencyamount-interface" aria-label="Permalink for Section 8."></a></div>
-      
-      <p>
-        The <code>MonetizationCurrencyAmount</code> interface maps directly to the
-        <a data-link-type="idl" data-lt="PaymentCurrencyAmount" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount"><code>PaymentCurrencyAmount</code></a> dictionary as defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-payment-request" title="Payment Request API">payment-request</a></cite>].
-      </p>
-      <pre class="idl def" id="webidl-385319265"><span class="idlHeader"><a class="self-link" href="#webidl-385319265">WebIDL</a></span><code><span data-idl="" class="idlInterface" id="idl-def-monetizationcurrencyamount" data-title="MonetizationCurrencyAmount">[<span class="extAttr"><a data-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext">SecureContext</a></span>, <span class="extAttr"><a data-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed">Exposed</a>=Window</span>]
-interface <dfn data-export="" data-dfn-type="interface" id="dom-monetizationcurrencyamount" data-idl="interface" data-title="MonetizationCurrencyAmount" data-dfn-for="" class="idlID" tabindex="0" aria-haspopup="dialog"><code>MonetizationCurrencyAmount</code></dfn> {<span data-idl="" class="idlAttribute" id="idl-def-monetizationcurrencyamount-currency" data-title="currency" data-dfn-for="MonetizationCurrencyAmount">
-  readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a></span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationcurrencyamount-currency" id="ref-for-dom-monetizationcurrencyamount-currency-1"><code>currency</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationcurrencyamount-value" data-title="value" data-dfn-for="MonetizationCurrencyAmount">
-  readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a></span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationcurrencyamount-value" id="ref-for-dom-monetizationcurrencyamount-value-1"><code>value</code></a>;</span>
-};</span></code></pre>
-      <section id="currency-member"><div class="header-wrapper"><h3 id="x8-1-currency-member"><bdi class="secno">8.1 </bdi>
-          <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationcurrencyamount-currency" data-idl="attribute" data-title="currency" data-dfn-for="MonetizationCurrencyAmount" data-type="DOMString" data-lt="currency" data-local-lt="MonetizationCurrencyAmount.currency" tabindex="0" aria-haspopup="dialog"><code>currency</code></dfn> member
-        </h3><a class="self-link" href="#currency-member" aria-label="Permalink for Section 8.1"></a></div>
-        
-        <p>
-          The currency of the MonetizationCurrencyAmount. See the definition of
-          the <code>currency</code> member of <a data-link-type="idl" data-lt="PaymentCurrencyAmount" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount"><code>PaymentCurrencyAmount</code></a> in
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-payment-request" title="Payment Request API">payment-request</a></cite>] for details.
-        </p>
       </section>
-      <section id="value-member"><div class="header-wrapper"><h3 id="x8-2-value-member"><bdi class="secno">8.2 </bdi>
-          <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationcurrencyamount-value" data-idl="attribute" data-title="value" data-dfn-for="MonetizationCurrencyAmount" data-type="DOMString" data-lt="value" data-local-lt="MonetizationCurrencyAmount.value" tabindex="0" aria-haspopup="dialog"><code>value</code></dfn> member
-        </h3><a class="self-link" href="#value-member" aria-label="Permalink for Section 8.2"></a></div>
+      <section id="task-sources"><div class="header-wrapper"><h2 id="x7-task-sources"><bdi class="secno">7. </bdi>
+          Task sources
+        </h2><a class="self-link" href="#task-sources" aria-label="Permalink for Section 7."></a></div>
         
         <p>
-          The amount of the MonetizationAmount. See the definition of the
-          <code>value</code> member in of <a data-link-type="idl" data-lt="PaymentCurrencyAmount" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount"><code>PaymentCurrencyAmount</code></a> in [<cite><a class="bibref" data-link-type="biblio" href="#bib-payment-request" title="Payment Request API">payment-request</a></cite>]
-          for details.
+          The following <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is defined by this specifications.
         </p>
+        <dl>
+          <dt>
+            The <dfn id="dfn-monetization-task-source" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">monetization task source</dfn>
+          </dt>
+          <dd>
+            Used by this specification to queue up non-blocking
+            <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-7"><code>MonetizationEvent</code></a>s.
+          </dd>
+        </dl>
       </section>
-    </section>
-    <section data-dfn-for="MonetizationEvent" id="monetizationevent-interface"><div class="header-wrapper"><h2 id="x9-monetizationevent-interface"><bdi class="secno">9. </bdi>
-        <code>MonetizationEvent</code> interface
-      </h2><a class="self-link" href="#monetizationevent-interface" aria-label="Permalink for Section 9."></a></div>
-      
-      <pre class="idl def" id="webidl-106886564"><span class="idlHeader"><a class="self-link" href="#webidl-106886564">WebIDL</a></span><code><span data-idl="" class="idlInterface" id="idl-def-monetizationevent" data-title="MonetizationEvent">[<span class="extAttr"><a data-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext">SecureContext</a></span>, <span class="extAttr"><a data-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed">Exposed</a>=Window</span>]
-interface <dfn data-export="" data-dfn-type="interface" id="dom-monetizationevent" data-idl="interface" data-title="MonetizationEvent" data-dfn-for="" class="idlID" tabindex="0" aria-haspopup="dialog"><code>MonetizationEvent</code></dfn> : <span class="idlSuperclass"><a data-link-type="idl" data-type="interface" href="https://dom.spec.whatwg.org/#event">Event</a></span> {<span data-idl="" class="idlConstructor" id="idl-def-monetizationevent-constructor-type-eventinitdict" data-title="constructor" data-dfn-for="MonetizationEvent">
-  <dfn data-export="" data-dfn-type="constructor" id="dom-monetizationevent-constructor" data-idl="constructor" data-title="constructor" data-dfn-for="MonetizationEvent" data-lt="constructor()|constructor(type, eventInitDict)" data-local-lt="MonetizationEvent.constructor|MonetizationEvent.constructor()|constructor" tabindex="0" aria-haspopup="dialog"><code>constructor</code></dfn>(<span class="idlType"><a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a></span> <span class="idlParamName">type</span>,<span class="idlType"> <a data-link-type="idl" href="#dom-monetizationeventinit" class="internalDFN" id="ref-for-dom-monetizationeventinit-2"><code>MonetizationEventInit</code></a></span> <span class="idlParamName">eventInitDict</span>);</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-amount" data-title="amount" data-dfn-for="MonetizationEvent">
-  readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a>?</span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-amount" id="ref-for-dom-monetizationevent-amount-1"><code>amount</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-assetcode" data-title="assetCode" data-dfn-for="MonetizationEvent">
-  readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a>?</span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-assetcode" id="ref-for-dom-monetizationevent-assetcode-1"><code>assetCode</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-assetscale" data-title="assetScale" data-dfn-for="MonetizationEvent">
-  readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-octet">octet</a>?</span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-assetscale" id="ref-for-dom-monetizationevent-assetscale-1"><code>assetScale</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-receipt" data-title="receipt" data-dfn-for="MonetizationEvent">
-  readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a>?</span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-receipt" id="ref-for-dom-monetizationevent-receipt-1"><code>receipt</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-amountsent" data-title="amountSent" data-dfn-for="MonetizationEvent">
-  readonly attribute<span class="idlType"> <a data-link-type="idl" href="#dom-monetizationcurrencyamount" class="internalDFN" id="ref-for-dom-monetizationcurrencyamount-1"><code>MonetizationCurrencyAmount</code></a></span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-amountsent" id="ref-for-dom-monetizationevent-amountsent-1"><code>amountSent</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-paymentpointer" data-title="paymentPointer" data-dfn-for="MonetizationEvent">
-  readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString">USVString</a></span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-paymentpointer" id="ref-for-dom-monetizationevent-paymentpointer-1"><code>paymentPointer</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-incomingpayment" data-title="incomingPayment" data-dfn-for="MonetizationEvent">
-  readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString">USVString</a>?</span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-incomingpayment" id="ref-for-dom-monetizationevent-incomingpayment-4"><code>incomingPayment</code></a>;</span>
-};</span><span data-idl="" class="idlDictionary" id="idl-def-monetizationeventinit" data-title="MonetizationEventInit">
-
-dictionary <dfn data-export="" data-dfn-type="dictionary" id="dom-monetizationeventinit" data-idl="dictionary" data-title="MonetizationEventInit" data-dfn-for="" class="idlID" tabindex="0" aria-haspopup="dialog"><code>MonetizationEventInit</code></dfn> : <span class="idlSuperclass"><a data-link-type="idl" data-type="dictionary" href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a></span> {<span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-amount" data-title="amount" data-dfn-for="MonetizationEventInit">
-  required<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a>?</span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-amount" data-idl="field" data-title="amount" data-dfn-for="MonetizationEventInit" data-type="DOMString" class="idlName" tabindex="0" aria-haspopup="dialog"><code>amount</code></dfn>;</span><span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-assetcode" data-title="assetCode" data-dfn-for="MonetizationEventInit">
-  required<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a>?</span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-assetcode" data-idl="field" data-title="assetCode" data-dfn-for="MonetizationEventInit" data-type="DOMString" class="idlName" tabindex="0" aria-haspopup="dialog"><code>assetCode</code></dfn>;</span><span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-assetscale" data-title="assetScale" data-dfn-for="MonetizationEventInit">
-  required<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-octet">octet</a>?</span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-assetscale" data-idl="field" data-title="assetScale" data-dfn-for="MonetizationEventInit" data-type="octet" class="idlName" tabindex="0" aria-haspopup="dialog"><code>assetScale</code></dfn>;</span><span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-receipt" data-title="receipt" data-dfn-for="MonetizationEventInit">
-  required<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a>?</span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-receipt" data-idl="field" data-title="receipt" data-dfn-for="MonetizationEventInit" data-type="DOMString" class="idlName" tabindex="0" aria-haspopup="dialog"><code>receipt</code></dfn>;</span><span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-amountsent" data-title="amountSent" data-dfn-for="MonetizationEventInit">
-  required<span class="idlType"> <a data-link-type="idl" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount">PaymentCurrencyAmount</a></span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-amountsent" data-idl="field" data-title="amountSent" data-dfn-for="MonetizationEventInit" data-type="PaymentCurrencyAmount" class="idlName" tabindex="0" aria-haspopup="dialog"><code>amountSent</code></dfn>;</span><span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-paymentpointer" data-title="paymentPointer" data-dfn-for="MonetizationEventInit">
-  required<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString">USVString</a></span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-paymentpointer" data-idl="field" data-title="paymentPointer" data-dfn-for="MonetizationEventInit" data-type="USVString" class="idlName" tabindex="0" aria-haspopup="dialog"><code>paymentPointer</code></dfn>;</span><span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-incomingpayment" data-title="incomingPayment" data-dfn-for="MonetizationEventInit">
-  required<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString">USVString</a>?</span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-incomingpayment" data-idl="field" data-title="incomingPayment" data-dfn-for="MonetizationEventInit" data-type="USVString" class="idlName" tabindex="0" aria-haspopup="dialog"><code>incomingPayment</code></dfn>;</span>
-};</span></code></pre>
-      <div class="warning" id="issue-container-generatedID-1"><div role="heading" class="warning-title marker" id="h-warning-0" aria-level="3"><span>Warning</span></div><div class="">
-        <p>
-          The <code>amount</code>, <code>assetCode</code>, <code>assetScale</code> and <code>receipt</code> attributes are
-          deprecated.
-        </p>
-        <p>
-          All <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-7">monetization receivers</a> should be migrating from generating a
-          <cite><a data-matched-text="[[[Receipt]]]" href="https://interledger.org/rfcs/0039-stream-receipts/">STREAM Receipt</a></cite> to supporting incoming payments via [<cite><a class="bibref" data-link-type="biblio" href="#bib-open payments" title="Open Payments">Open Payments</a></cite>]
-          and will no longer be returning receipts to the browser.
-        </p>
-        <p>
-          As such the <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-8"><code>MonetizationEvent</code></a> no longer represents an amount
-          received, it represents an amount sent and returns a URL as the
-          <a data-link-type="idl" href="#dom-monetizationevent-incomingpayment" class="internalDFN" id="ref-for-dom-monetizationevent-incomingpayment-5"><code>incomingPayment</code></a> attribute that can be used to
-          determine the amount received.
-        </p>
-      </div></div>
-      <section id="amount-attribute-deprecated"><div class="header-wrapper"><h3 id="x9-1-amount-attribute-deprecated"><bdi class="secno">9.1 </bdi>
-          <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-amount" data-idl="attribute" data-title="amount" data-dfn-for="MonetizationEvent" data-type="DOMString" data-lt="amount" data-local-lt="MonetizationEvent.amount" tabindex="0" aria-haspopup="dialog"><code>amount</code></dfn> attribute (deprecated)
-        </h3><a class="self-link" href="#amount-attribute-deprecated" aria-label="Permalink for Section 9.1"></a></div>
+      <section data-dfn-for="MonetizationCurrencyAmount" id="monetizationcurrencyamount-interface"><div class="header-wrapper"><h2 id="x8-monetizationcurrencyamount-interface"><bdi class="secno">8. </bdi>
+          <code>MonetizationCurrencyAmount</code> interface
+        </h2><a class="self-link" href="#monetizationcurrencyamount-interface" aria-label="Permalink for Section 8."></a></div>
         
         <p>
-          The amount <em>received</em> as reflected in the receipt from the
-          <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-8">monetization receiver</a>. When getting, returns the value it was
-          initialized with.
+          The <code>MonetizationCurrencyAmount</code> interface maps directly to the
+          <a data-link-type="idl" data-lt="PaymentCurrencyAmount" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount"><code>PaymentCurrencyAmount</code></a> dictionary as defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-payment-request" title="Payment Request API">payment-request</a></cite>].
         </p>
-      </section>
-      <section id="assetcode-attribute-deprecated"><div class="header-wrapper"><h3 id="x9-2-assetcode-attribute-deprecated"><bdi class="secno">9.2 </bdi>
-          <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-assetcode" data-idl="attribute" data-title="assetCode" data-dfn-for="MonetizationEvent" data-type="DOMString" data-lt="assetCode" data-local-lt="MonetizationEvent.assetCode" tabindex="0" aria-haspopup="dialog"><code>assetCode</code></dfn> attribute (deprecated)
-        </h3><a class="self-link" href="#assetcode-attribute-deprecated" aria-label="Permalink for Section 9.2"></a></div>
-        
-        <p>
-          The three letter asset code identifying the amount's units (e.g.,
-          "USD" for US dollars). When getting, returns the value it was
-          initialized with.
-        </p>
-      </section>
-      <section id="assetscale-attribute-deprecated"><div class="header-wrapper"><h3 id="x9-3-assetscale-attribute-deprecated"><bdi class="secno">9.3 </bdi>
-          <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-assetscale" data-idl="attribute" data-title="assetScale" data-dfn-for="MonetizationEvent" data-type="octet" data-lt="assetScale" data-local-lt="MonetizationEvent.assetScale" tabindex="0" aria-haspopup="dialog"><code>assetScale</code></dfn> attribute (deprecated)
-        </h3><a class="self-link" href="#assetscale-attribute-deprecated" aria-label="Permalink for Section 9.3"></a></div>
-        
-        <p>
-          The scale of the amount. For example, USD would have an
-          <code>assetScale</code> of <code>2</code> when denominated in cents.
-          When getting, returns the value it was initialized with.
-        </p>
-      </section>
-      <div class="note" role="note" id="issue-container-generatedID-2"><div role="heading" class="note-title marker" id="h-note-0" aria-level="3"><span>Note</span><span class="issue-label">: MonetizationCurrencyAmount</span></div><div class="">
-        The members of the <code>MonetizationCurrencyAmount</code> interface map directly
-        to the <code>value</code> and <code>currency</code> attributes of a <a data-link-type="idl" data-lt="PaymentCurrencyAmount" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount"><code>PaymentCurrencyAmount</code></a>
-        dictionary. See the documentation of <a data-link-type="idl" data-lt="PaymentCurrencyAmount" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount"><code>PaymentCurrencyAmount</code></a> for
-        guidance on processing and display of these attributes.
-      </div></div>
-      <section id="amountsent-attribute"><div class="header-wrapper"><h3 id="x9-4-amountsent-attribute"><bdi class="secno">9.4 </bdi>
-          <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-amountsent" data-idl="attribute" data-title="amountSent" data-dfn-for="MonetizationEvent" data-type="MonetizationCurrencyAmount" data-lt="amountSent" data-local-lt="MonetizationEvent.amountSent" tabindex="0" aria-haspopup="dialog"><code>amountSent</code></dfn> attribute
-        </h3><a class="self-link" href="#amountsent-attribute" aria-label="Permalink for Section 9.4"></a></div>
-        
-        <p>
-          The amount <em>sent</em>. This should be processed in the same way as
-          a <a data-link-type="idl" data-lt="PaymentCurrencyAmount" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount"><code>PaymentCurrencyAmount</code></a> dictionary as defined in
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-payment-request" title="Payment Request API">payment-request</a></cite>]. When getting, returns the value it was
-          initialized with.
-        </p>
-      </section>
-      <section id="receipt-attribute-deprecated"><div class="header-wrapper"><h3 id="x9-5-receipt-attribute-deprecated"><bdi class="secno">9.5 </bdi>
-          <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-receipt" data-idl="attribute" data-title="receipt" data-dfn-for="MonetizationEvent" data-type="DOMString" data-lt="receipt" data-local-lt="MonetizationEvent.receipt" tabindex="0" aria-haspopup="dialog"><code>receipt</code></dfn> attribute (deprecated)
-        </h3><a class="self-link" href="#receipt-attribute-deprecated" aria-label="Permalink for Section 9.5"></a></div>
-        
-        <p>
-          <code>null</code> or a base64-encoded <cite><a data-matched-text="[[[Receipt]]]" href="https://interledger.org/rfcs/0039-stream-receipts/">STREAM Receipt</a></cite> issued by the <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-9">monetization receiver</a> to the <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-4">monetization provider</a> as proof of the total
-          amount received in the <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-7">payment session</a>. When getting, returns the
-          value it was initialized with.
-        </p>
-      </section>
-      <section id="paymentpointer-attribute"><div class="header-wrapper"><h3 id="x9-6-paymentpointer-attribute"><bdi class="secno">9.6 </bdi>
-          <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-paymentpointer" data-idl="attribute" data-title="paymentPointer" data-dfn-for="MonetizationEvent" data-type="USVString" data-lt="paymentPointer" data-local-lt="MonetizationEvent.paymentPointer" tabindex="0" aria-haspopup="dialog"><code>paymentPointer</code></dfn> attribute
-        </h3><a class="self-link" href="#paymentpointer-attribute" aria-label="Permalink for Section 9.6"></a></div>
-        
-        <p>
-          A <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> representing the <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-4">payment pointer</a> that has been
-          monetized. When getting, returns the value it was initialized with.
-        </p>
-      </section>
-      <section id="incomingpayment-attribute"><div class="header-wrapper"><h3 id="x9-7-incomingpayment-attribute"><bdi class="secno">9.7 </bdi>
-          <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-incomingpayment" data-idl="attribute" data-title="incomingPayment" data-dfn-for="MonetizationEvent" data-type="USVString" data-lt="incomingPayment" data-local-lt="MonetizationEvent.incomingPayment" tabindex="0" aria-haspopup="dialog"><code>incomingPayment</code></dfn> attribute
-        </h3><a class="self-link" href="#incomingpayment-attribute" aria-label="Permalink for Section 9.7"></a></div>
-        
-        <p>
-          A <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> representing an incoming payment at the <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-10">monetization receiver</a>. When getting, returns the value it was initialized with.
-        </p>
-      </section>
-    </section>
-    <section id="permissions-policy" data-cite="permissions-policy"><div class="header-wrapper"><h2 id="x10-permissions-policy-integration"><bdi class="secno">10. </bdi>
-        Permissions Policy integration
-      </h2><a class="self-link" href="#permissions-policy" aria-label="Permalink for Section 10."></a></div>
-      
-      <p>
-        This specification defines a <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://www.w3.org/TR/permissions-policy-1/#policy-controlled-feature">policy-controlled feature</a> identified
-        by the string <dfn class="permission export" data-dfn-type="permission" data-export="" id="dfn-monetization" tabindex="0" aria-haspopup="dialog">"monetization"</dfn>. Its
-        default <a data-type="dfn" href="https://www.w3.org/TR/permissions-policy-1/#allowlist">allowlist</a> is <code>'self'</code>.
-      </p>
-      <div class="note" role="note" id="issue-container-generatedID-3"><div role="heading" class="note-title marker" id="h-note-1" aria-level="3"><span>Note</span></div><aside class="">
-        <p>
-          A <a data-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">document</a>'s <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy">permissions policy</a> determines
-          whether <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> elements are monetized - particularly in third-party
-          content, such as an <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">iframe</a></code>. When disabled, monetization is
-          disabled and related events won't be dispatched.
-        </p>
-      </aside></div>
-    </section>
-    <section data-cite="CSP" id="content-security-policy"><div class="header-wrapper"><h2 id="x11-content-security-policy"><bdi class="secno">11. </bdi>
-        Content Security Policy
-      </h2><a class="self-link" href="#content-security-policy" aria-label="Permalink for Section 11."></a></div>
-      
-      <div class="note" role="note" id="issue-container-generatedID-4"><div role="heading" class="note-title marker" id="h-note-2" aria-level="3"><span>Note</span><span class="issue-label">: Monkey patch 🐒</span></div><p class="">
-        This section will eventually be moved into the [<cite><a class="bibref" data-link-type="biblio" href="#bib-csp" title="Content Security Policy Level 3">CSP</a></cite>] and [<cite><a class="bibref" data-link-type="biblio" href="#bib-fetch" title="Fetch Standard">FETCH</a></cite>]
-        specifications.
-      </p></div>
-      <section id="monetization-src-directive"><div class="header-wrapper"><h3 id="x11-1-monetization-src-directive"><bdi class="secno">11.1 </bdi>
-          <dfn class="export" data-export="" id="dfn-monetization-src" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">monetization-src</dfn> directive
-        </h3><a class="self-link" href="#monetization-src-directive" aria-label="Permalink for Section 11.1"></a></div>
-        
-        <p>
-          The monetization-src directive restricts the URLs from which a
-          <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-5">payment pointer</a> is loaded. The syntax for the directive's name
-          and value is described by the following ABNF:
-        </p>
-        <pre aria-busy="false"><code class="hljs abnf"><span class="hljs-attribute">directive-name</span>  = <span class="hljs-string">"monetization-src"</span>
-<span class="hljs-attribute">directive-value</span> = serialized-source-list</code></pre>
-        <aside class="example" id="example-6"><div class="marker">
-    <a class="self-link" href="#example-6">Example<bdi> 6</bdi></a>
-  </div>
-          <p>
-            Given a page with the following Content Security Policy:
-          </p>
-          <pre class="http" aria-busy="false"><code class="hljs">Content-Security-Policy: monetization-src https://example.com/</code></pre>
-          <p>
-            Fetches for the following code will return a network errors, as the
-            URL provided do not match monetization-src's source list:
-          </p>
-          <pre aria-busy="false"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">link</span> <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.org/payment-pointer"</span>&gt;</span></code></pre>
-        </aside>
-        <section data-cite="CSP" id="monetization-src-pre-request-check"><div class="header-wrapper"><h4 id="x11-1-1-monetization-src-pre-request-check"><bdi class="secno">11.1.1 </bdi>
-            <code>monetization-src</code> Pre-request check
-          </h4><a class="self-link" href="#monetization-src-pre-request-check" aria-label="Permalink for Section 11.1.1"></a></div>
+        <pre class="idl def" id="webidl-385319265"><span class="idlHeader"><a class="self-link" href="#webidl-385319265">WebIDL</a></span><code><span data-idl="" class="idlInterface" id="idl-def-monetizationcurrencyamount" data-title="MonetizationCurrencyAmount">[<span class="extAttr"><a data-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext">SecureContext</a></span>, <span class="extAttr"><a data-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed">Exposed</a>=Window</span>]
+  interface <dfn data-export="" data-dfn-type="interface" id="dom-monetizationcurrencyamount" data-idl="interface" data-title="MonetizationCurrencyAmount" data-dfn-for="" class="idlID" tabindex="0" aria-haspopup="dialog"><code>MonetizationCurrencyAmount</code></dfn> {<span data-idl="" class="idlAttribute" id="idl-def-monetizationcurrencyamount-currency" data-title="currency" data-dfn-for="MonetizationCurrencyAmount">
+    readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a></span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationcurrencyamount-currency" id="ref-for-dom-monetizationcurrencyamount-currency-1"><code>currency</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationcurrencyamount-value" data-title="value" data-dfn-for="MonetizationCurrencyAmount">
+    readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a></span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationcurrencyamount-value" id="ref-for-dom-monetizationcurrencyamount-value-1"><code>value</code></a>;</span>
+  };</span></code></pre>
+        <section id="currency-member"><div class="header-wrapper"><h3 id="x8-1-currency-member"><bdi class="secno">8.1 </bdi>
+            <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationcurrencyamount-currency" data-idl="attribute" data-title="currency" data-dfn-for="MonetizationCurrencyAmount" data-type="DOMString" data-lt="currency" data-local-lt="MonetizationCurrencyAmount.currency" tabindex="0" aria-haspopup="dialog"><code>currency</code></dfn> member
+          </h3><a class="self-link" href="#currency-member" aria-label="Permalink for Section 8.1"></a></div>
           
           <p>
-            This directive's pre-request check is as follows:
+            The currency of the MonetizationCurrencyAmount. See the definition of
+            the <code>currency</code> member of <a data-link-type="idl" data-lt="PaymentCurrencyAmount" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount"><code>PaymentCurrencyAmount</code></a> in
+            [<cite><a class="bibref" data-link-type="biblio" href="#bib-payment-request" title="Payment Request API">payment-request</a></cite>] for details.
           </p>
-          <p>
-            Given a <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://www.w3.org/TR/CSP3/#violation-policy">policy</a>
-            (<var>policy</var>):
-          </p>
-          <ol class="algorithm">
-            <li>Let <var>name</var> be the result of executing "Get the effective
-            directive for request" on <var>request</var>.
-            </li>
-            <li>If the result of executing "Should fetch directive execute" on
-            <var>name</var>, <code>monetization-src</code> and <var>policy</var> is "No", return "Allowed".
-            </li>
-            <li>If the result of executing "Does request match source list?" on
-            <var>request</var>, this directive's value, and <var>policy</var>, is "Does Not
-            Match", return "Blocked".
-            </li>
-            <li>Return "Allowed".
-            </li>
-          </ol>
         </section>
-        <section id="monetization-src-post-request-check"><div class="header-wrapper"><h4 id="x11-1-2-monetization-src-post-request-check"><bdi class="secno">11.1.2 </bdi>
-            <code>monetization-src</code> Post-request check
-          </h4><a class="self-link" href="#monetization-src-post-request-check" aria-label="Permalink for Section 11.1.2"></a></div>
+        <section id="value-member"><div class="header-wrapper"><h3 id="x8-2-value-member"><bdi class="secno">8.2 </bdi>
+            <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationcurrencyamount-value" data-idl="attribute" data-title="value" data-dfn-for="MonetizationCurrencyAmount" data-type="DOMString" data-lt="value" data-local-lt="MonetizationCurrencyAmount.value" tabindex="0" aria-haspopup="dialog"><code>value</code></dfn> member
+          </h3><a class="self-link" href="#value-member" aria-label="Permalink for Section 8.2"></a></div>
           
           <p>
-            This directive's post-request check is as follows:
+            The amount of the MonetizationAmount. See the definition of the
+            <code>value</code> member in of <a data-link-type="idl" data-lt="PaymentCurrencyAmount" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount"><code>PaymentCurrencyAmount</code></a> in [<cite><a class="bibref" data-link-type="biblio" href="#bib-payment-request" title="Payment Request API">payment-request</a></cite>]
+            for details.
           </p>
-          <p>
-            Given a <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://www.w3.org/TR/CSP3/#violation-policy">policy</a>
-            (<var>policy</var>):
-          </p>
-          <ol>
-            <li>Let <var>name</var> be the result of executing "Get the effective
-            directive for request" on <var>request</var>.
-            </li>
-            <li>If the result of executing "Should fetch directive execute" on
-            <var>name</var>, <code>monetization-src</code> and <var>policy</var> is "No", return "Allowed".
-            </li>
-            <li>If the result of executing "Does response to request match
-            source list?" on <var>response</var>, <var>request</var>, this directive's value, and
-            <var>policy</var>, is "Does Not Match", return "Blocked".
-            </li>
-            <li>Return "Allowed".
-            </li>
-          </ol>
         </section>
       </section>
-    </section>
-    <section id="security-considerations"><div class="header-wrapper"><h2 id="x12-security-considerations"><bdi class="secno">12. </bdi>
-        Security considerations
-      </h2><a class="self-link" href="#security-considerations" aria-label="Permalink for Section 12."></a></div>
-      
-      <p>
-        It is <em class="rfc2119">RECOMMENDED</em> that a user agent provide some UI or indicator that
-        allows the user to know when <a data-link-type="dfn|abstract-op" href="#dfn-monetized" class="internalDFN" id="ref-for-dfn-monetized-2">monetization</a> is possible and/or when
-        <a data-link-type="dfn|abstract-op" href="#dfn-monetized" class="internalDFN" id="ref-for-dfn-monetized-3">monetization</a> is occurring. Providing such a UI allows the users to
-        retain control of the monetization process by taking action (e.g., stop
-        or start monetization of a particular site if they wish to do so).
-      </p>
-      <p>
-        As <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-6">payment pointers</a> are generally provided as a service (e.g.,
-        Uphold), a <abbr title="Cross Site Scripting">XSS</abbr> attack could
-        inject malicious <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-7">payment pointers</a> into a page that uses the same
-        service. To mitigate such an attack, it is <em class="rfc2119">RECOMMENDED</em> that developers:
-      </p>
-      <ul>
-        <li>host a <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-8">payment pointer</a> on their own servers and proxy [<cite><a class="bibref" data-link-type="biblio" href="#bib-open payments" title="Open Payments">Open Payments</a></cite>] requests on the server as needed.
-        </li>
-        <li>Set the <code>monetization-src</code> CSP directive to restrict requests to
-        origins they control and trust to host <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-9">payment pointers</a>.
-        </li>
-      </ul>
-    </section>
-    <section id="privacy-considerations"><div class="header-wrapper"><h2 id="x13-privacy-considerations"><bdi class="secno">13. </bdi>
-        Privacy considerations
-      </h2><a class="self-link" href="#privacy-considerations" aria-label="Permalink for Section 13."></a></div>
-      
-      <p>
-        Web Monetization is designed to be privacy-preserving: The user agent
-        does not send any data to the <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-5">monetization provider</a>. Instead, it
-        requests data from the <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-6">monetization provider</a> without ever revealing
-        the URL of the web page the user is currently browsing.
-      </p>
-      <p>
-        Further, the user agent gets the payment information from the <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-10">payment pointer</a> to establish the <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-8">payment session</a>. This also ensures the
-        <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-7">monetization provider</a> doesn't have access to a user's browsing
-        history or to the <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-11">payment pointer</a>.
-      </p>
-    </section>
-    <section id="relation-to-other-technologies" class="informative"><div class="header-wrapper"><h2 id="x14-relation-to-web-payments"><bdi class="secno">14. </bdi>
-        Relation to Web Payments
-      </h2><a class="self-link" href="#relation-to-other-technologies" aria-label="Permalink for Section 14."></a></div><p><em>This section is non-normative.</em></p>
-      
-      <p>
-        Unlike <cite><a data-matched-text="[[[Payment-Request]]]" href="https://www.w3.org/TR/payment-request/">Payment Request API</a></cite> and the <cite><a data-matched-text="[[[Payment-Handler]]]" href="https://www.w3.org/TR/payment-handler/">Payment Handler API</a></cite>, which only
-        supports "one-off" payments, Web Monetization provides a <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-9">payment session</a> that supports both continuous payments and "one-off"
-        payments.
-      </p>
-    </section>
-    <section id="conformance" class="appendix"><div class="header-wrapper"><h2 id="a-conformance"><bdi class="secno">A. </bdi>Conformance</h2><a class="self-link" href="#conformance" aria-label="Permalink for Appendix A."></a></div><p>As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.</p><p>
-        The key words <em class="rfc2119">MUST</em>, <em class="rfc2119">MUST NOT</em>, and <em class="rfc2119">RECOMMENDED</em> in this document
-        are to be interpreted as described in
-        <a href="https://datatracker.ietf.org/doc/html/bcp14">BCP 14</a>
-        [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8174" title="Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words">RFC8174</a></cite>]
-        when, and only when, they appear in all capitals, as shown here.
-      </p></section>
+      <section data-dfn-for="MonetizationEvent" id="monetizationevent-interface"><div class="header-wrapper"><h2 id="x9-monetizationevent-interface"><bdi class="secno">9. </bdi>
+          <code>MonetizationEvent</code> interface
+        </h2><a class="self-link" href="#monetizationevent-interface" aria-label="Permalink for Section 9."></a></div>
+        
+        <pre class="idl def" id="webidl-106886564"><span class="idlHeader"><a class="self-link" href="#webidl-106886564">WebIDL</a></span><code><span data-idl="" class="idlInterface" id="idl-def-monetizationevent" data-title="MonetizationEvent">[<span class="extAttr"><a data-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext">SecureContext</a></span>, <span class="extAttr"><a data-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed">Exposed</a>=Window</span>]
+  interface <dfn data-export="" data-dfn-type="interface" id="dom-monetizationevent" data-idl="interface" data-title="MonetizationEvent" data-dfn-for="" class="idlID" tabindex="0" aria-haspopup="dialog"><code>MonetizationEvent</code></dfn> : <span class="idlSuperclass"><a data-link-type="idl" data-type="interface" href="https://dom.spec.whatwg.org/#event">Event</a></span> {<span data-idl="" class="idlConstructor" id="idl-def-monetizationevent-constructor-type-eventinitdict" data-title="constructor" data-dfn-for="MonetizationEvent">
+    <dfn data-export="" data-dfn-type="constructor" id="dom-monetizationevent-constructor" data-idl="constructor" data-title="constructor" data-dfn-for="MonetizationEvent" data-lt="constructor()|constructor(type, eventInitDict)" data-local-lt="MonetizationEvent.constructor|MonetizationEvent.constructor()|constructor" tabindex="0" aria-haspopup="dialog"><code>constructor</code></dfn>(<span class="idlType"><a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a></span> <span class="idlParamName">type</span>,<span class="idlType"> <a data-link-type="idl" href="#dom-monetizationeventinit" class="internalDFN" id="ref-for-dom-monetizationeventinit-2"><code>MonetizationEventInit</code></a></span> <span class="idlParamName">eventInitDict</span>);</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-amount" data-title="amount" data-dfn-for="MonetizationEvent">
+    readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a>?</span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-amount" id="ref-for-dom-monetizationevent-amount-1"><code>amount</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-assetcode" data-title="assetCode" data-dfn-for="MonetizationEvent">
+    readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a>?</span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-assetcode" id="ref-for-dom-monetizationevent-assetcode-1"><code>assetCode</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-assetscale" data-title="assetScale" data-dfn-for="MonetizationEvent">
+    readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-octet">octet</a>?</span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-assetscale" id="ref-for-dom-monetizationevent-assetscale-1"><code>assetScale</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-receipt" data-title="receipt" data-dfn-for="MonetizationEvent">
+    readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a>?</span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-receipt" id="ref-for-dom-monetizationevent-receipt-1"><code>receipt</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-amountsent" data-title="amountSent" data-dfn-for="MonetizationEvent">
+    readonly attribute<span class="idlType"> <a data-link-type="idl" href="#dom-monetizationcurrencyamount" class="internalDFN" id="ref-for-dom-monetizationcurrencyamount-1"><code>MonetizationCurrencyAmount</code></a></span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-amountsent" id="ref-for-dom-monetizationevent-amountsent-1"><code>amountSent</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-paymentpointer" data-title="paymentPointer" data-dfn-for="MonetizationEvent">
+    readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString">USVString</a></span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-paymentpointer" id="ref-for-dom-monetizationevent-paymentpointer-1"><code>paymentPointer</code></a>;</span><span data-idl="" class="idlAttribute" id="idl-def-monetizationevent-incomingpayment" data-title="incomingPayment" data-dfn-for="MonetizationEvent">
+    readonly attribute<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString">USVString</a>?</span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-monetizationevent-incomingpayment" id="ref-for-dom-monetizationevent-incomingpayment-4"><code>incomingPayment</code></a>;</span>
+  };</span><span data-idl="" class="idlDictionary" id="idl-def-monetizationeventinit" data-title="MonetizationEventInit">
   
-
-<section id="references" class="appendix"><div class="header-wrapper"><h2 id="b-references"><bdi class="secno">B. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix B."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="b-1-normative-references"><bdi class="secno">B.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix B.1"></a></div>
+  dictionary <dfn data-export="" data-dfn-type="dictionary" id="dom-monetizationeventinit" data-idl="dictionary" data-title="MonetizationEventInit" data-dfn-for="" class="idlID" tabindex="0" aria-haspopup="dialog"><code>MonetizationEventInit</code></dfn> : <span class="idlSuperclass"><a data-link-type="idl" data-type="dictionary" href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a></span> {<span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-amount" data-title="amount" data-dfn-for="MonetizationEventInit">
+    required<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a>?</span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-amount" data-idl="field" data-title="amount" data-dfn-for="MonetizationEventInit" data-type="DOMString" class="idlName" tabindex="0" aria-haspopup="dialog"><code>amount</code></dfn>;</span><span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-assetcode" data-title="assetCode" data-dfn-for="MonetizationEventInit">
+    required<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a>?</span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-assetcode" data-idl="field" data-title="assetCode" data-dfn-for="MonetizationEventInit" data-type="DOMString" class="idlName" tabindex="0" aria-haspopup="dialog"><code>assetCode</code></dfn>;</span><span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-assetscale" data-title="assetScale" data-dfn-for="MonetizationEventInit">
+    required<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-octet">octet</a>?</span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-assetscale" data-idl="field" data-title="assetScale" data-dfn-for="MonetizationEventInit" data-type="octet" class="idlName" tabindex="0" aria-haspopup="dialog"><code>assetScale</code></dfn>;</span><span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-receipt" data-title="receipt" data-dfn-for="MonetizationEventInit">
+    required<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString">DOMString</a>?</span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-receipt" data-idl="field" data-title="receipt" data-dfn-for="MonetizationEventInit" data-type="DOMString" class="idlName" tabindex="0" aria-haspopup="dialog"><code>receipt</code></dfn>;</span><span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-amountsent" data-title="amountSent" data-dfn-for="MonetizationEventInit">
+    required<span class="idlType"> <a data-link-type="idl" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount">PaymentCurrencyAmount</a></span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-amountsent" data-idl="field" data-title="amountSent" data-dfn-for="MonetizationEventInit" data-type="PaymentCurrencyAmount" class="idlName" tabindex="0" aria-haspopup="dialog"><code>amountSent</code></dfn>;</span><span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-paymentpointer" data-title="paymentPointer" data-dfn-for="MonetizationEventInit">
+    required<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString">USVString</a></span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-paymentpointer" data-idl="field" data-title="paymentPointer" data-dfn-for="MonetizationEventInit" data-type="USVString" class="idlName" tabindex="0" aria-haspopup="dialog"><code>paymentPointer</code></dfn>;</span><span data-idl="" class="idlMember" id="idl-def-monetizationeventinit-incomingpayment" data-title="incomingPayment" data-dfn-for="MonetizationEventInit">
+    required<span class="idlType"> <a data-link-type="idl" data-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString">USVString</a>?</span> <dfn data-export="" data-dfn-type="dict-member" id="dom-monetizationeventinit-incomingpayment" data-idl="field" data-title="incomingPayment" data-dfn-for="MonetizationEventInit" data-type="USVString" class="idlName" tabindex="0" aria-haspopup="dialog"><code>incomingPayment</code></dfn>;</span>
+  };</span></code></pre>
+        <div class="warning" id="issue-container-generatedID-1"><div role="heading" class="warning-title marker" id="h-warning-0" aria-level="3"><span>Warning</span></div><div class="">
+          <p>
+            The <code>amount</code>, <code>assetCode</code>, <code>assetScale</code> and <code>receipt</code> attributes are
+            deprecated.
+          </p>
+          <p>
+            All <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-7">monetization receivers</a> should be migrating from generating a
+            <cite><a data-matched-text="[[[Receipt]]]" href="https://interledger.org/rfcs/0039-stream-receipts/">STREAM Receipt</a></cite> to supporting incoming payments via [<cite><a class="bibref" data-link-type="biblio" href="#bib-open payments" title="Open Payments">Open Payments</a></cite>]
+            and will no longer be returning receipts to the browser.
+          </p>
+          <p>
+            As such the <a data-link-type="idl" data-lt="MonetizationEvent" href="#dom-monetizationevent" class="internalDFN" id="ref-for-dom-monetizationevent-8"><code>MonetizationEvent</code></a> no longer represents an amount
+            received, it represents an amount sent and returns a URL as the
+            <a data-link-type="idl" href="#dom-monetizationevent-incomingpayment" class="internalDFN" id="ref-for-dom-monetizationevent-incomingpayment-5"><code>incomingPayment</code></a> attribute that can be used to
+            determine the amount received.
+          </p>
+        </div></div>
+        <section id="amount-attribute-deprecated"><div class="header-wrapper"><h3 id="x9-1-amount-attribute-deprecated"><bdi class="secno">9.1 </bdi>
+            <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-amount" data-idl="attribute" data-title="amount" data-dfn-for="MonetizationEvent" data-type="DOMString" data-lt="amount" data-local-lt="MonetizationEvent.amount" tabindex="0" aria-haspopup="dialog"><code>amount</code></dfn> attribute (deprecated)
+          </h3><a class="self-link" href="#amount-attribute-deprecated" aria-label="Permalink for Section 9.1"></a></div>
+          
+          <p>
+            The amount <em>received</em> as reflected in the receipt from the
+            <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-8">monetization receiver</a>. When getting, returns the value it was
+            initialized with.
+          </p>
+        </section>
+        <section id="assetcode-attribute-deprecated"><div class="header-wrapper"><h3 id="x9-2-assetcode-attribute-deprecated"><bdi class="secno">9.2 </bdi>
+            <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-assetcode" data-idl="attribute" data-title="assetCode" data-dfn-for="MonetizationEvent" data-type="DOMString" data-lt="assetCode" data-local-lt="MonetizationEvent.assetCode" tabindex="0" aria-haspopup="dialog"><code>assetCode</code></dfn> attribute (deprecated)
+          </h3><a class="self-link" href="#assetcode-attribute-deprecated" aria-label="Permalink for Section 9.2"></a></div>
+          
+          <p>
+            The three letter asset code identifying the amount's units (e.g.,
+            "USD" for US dollars). When getting, returns the value it was
+            initialized with.
+          </p>
+        </section>
+        <section id="assetscale-attribute-deprecated"><div class="header-wrapper"><h3 id="x9-3-assetscale-attribute-deprecated"><bdi class="secno">9.3 </bdi>
+            <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-assetscale" data-idl="attribute" data-title="assetScale" data-dfn-for="MonetizationEvent" data-type="octet" data-lt="assetScale" data-local-lt="MonetizationEvent.assetScale" tabindex="0" aria-haspopup="dialog"><code>assetScale</code></dfn> attribute (deprecated)
+          </h3><a class="self-link" href="#assetscale-attribute-deprecated" aria-label="Permalink for Section 9.3"></a></div>
+          
+          <p>
+            The scale of the amount. For example, USD would have an
+            <code>assetScale</code> of <code>2</code> when denominated in cents.
+            When getting, returns the value it was initialized with.
+          </p>
+        </section>
+        <div class="note" role="note" id="issue-container-generatedID-2"><div role="heading" class="note-title marker" id="h-note-0" aria-level="3"><span>Note</span><span class="issue-label">: MonetizationCurrencyAmount</span></div><div class="">
+          The members of the <code>MonetizationCurrencyAmount</code> interface map directly
+          to the <code>value</code> and <code>currency</code> attributes of a <a data-link-type="idl" data-lt="PaymentCurrencyAmount" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount"><code>PaymentCurrencyAmount</code></a>
+          dictionary. See the documentation of <a data-link-type="idl" data-lt="PaymentCurrencyAmount" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount"><code>PaymentCurrencyAmount</code></a> for
+          guidance on processing and display of these attributes.
+        </div></div>
+        <section id="amountsent-attribute"><div class="header-wrapper"><h3 id="x9-4-amountsent-attribute"><bdi class="secno">9.4 </bdi>
+            <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-amountsent" data-idl="attribute" data-title="amountSent" data-dfn-for="MonetizationEvent" data-type="MonetizationCurrencyAmount" data-lt="amountSent" data-local-lt="MonetizationEvent.amountSent" tabindex="0" aria-haspopup="dialog"><code>amountSent</code></dfn> attribute
+          </h3><a class="self-link" href="#amountsent-attribute" aria-label="Permalink for Section 9.4"></a></div>
+          
+          <p>
+            The amount <em>sent</em>. This should be processed in the same way as
+            a <a data-link-type="idl" data-lt="PaymentCurrencyAmount" data-type="dictionary" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount"><code>PaymentCurrencyAmount</code></a> dictionary as defined in
+            [<cite><a class="bibref" data-link-type="biblio" href="#bib-payment-request" title="Payment Request API">payment-request</a></cite>]. When getting, returns the value it was
+            initialized with.
+          </p>
+        </section>
+        <section id="receipt-attribute-deprecated"><div class="header-wrapper"><h3 id="x9-5-receipt-attribute-deprecated"><bdi class="secno">9.5 </bdi>
+            <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-receipt" data-idl="attribute" data-title="receipt" data-dfn-for="MonetizationEvent" data-type="DOMString" data-lt="receipt" data-local-lt="MonetizationEvent.receipt" tabindex="0" aria-haspopup="dialog"><code>receipt</code></dfn> attribute (deprecated)
+          </h3><a class="self-link" href="#receipt-attribute-deprecated" aria-label="Permalink for Section 9.5"></a></div>
+          
+          <p>
+            <code>null</code> or a base64-encoded <cite><a data-matched-text="[[[Receipt]]]" href="https://interledger.org/rfcs/0039-stream-receipts/">STREAM Receipt</a></cite> issued by the <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-9">monetization receiver</a> to the <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-4">monetization provider</a> as proof of the total
+            amount received in the <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-7">payment session</a>. When getting, returns the
+            value it was initialized with.
+          </p>
+        </section>
+        <section id="paymentpointer-attribute"><div class="header-wrapper"><h3 id="x9-6-paymentpointer-attribute"><bdi class="secno">9.6 </bdi>
+            <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-paymentpointer" data-idl="attribute" data-title="paymentPointer" data-dfn-for="MonetizationEvent" data-type="USVString" data-lt="paymentPointer" data-local-lt="MonetizationEvent.paymentPointer" tabindex="0" aria-haspopup="dialog"><code>paymentPointer</code></dfn> attribute
+          </h3><a class="self-link" href="#paymentpointer-attribute" aria-label="Permalink for Section 9.6"></a></div>
+          
+          <p>
+            A <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> representing the <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-4">payment pointer</a> that has been
+            monetized. When getting, returns the value it was initialized with.
+          </p>
+        </section>
+        <section id="incomingpayment-attribute"><div class="header-wrapper"><h3 id="x9-7-incomingpayment-attribute"><bdi class="secno">9.7 </bdi>
+            <dfn data-export="" data-dfn-type="attribute" id="dom-monetizationevent-incomingpayment" data-idl="attribute" data-title="incomingPayment" data-dfn-for="MonetizationEvent" data-type="USVString" data-lt="incomingPayment" data-local-lt="MonetizationEvent.incomingPayment" tabindex="0" aria-haspopup="dialog"><code>incomingPayment</code></dfn> attribute
+          </h3><a class="self-link" href="#incomingpayment-attribute" aria-label="Permalink for Section 9.7"></a></div>
+          
+          <p>
+            A <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> representing an incoming payment at the <a data-link-type="dfn|abstract-op" href="#dfn-monetization-receiver" class="internalDFN" id="ref-for-dfn-monetization-receiver-10">monetization receiver</a>. When getting, returns the value it was initialized with.
+          </p>
+        </section>
+      </section>
+      <section id="permissions-policy" data-cite="permissions-policy"><div class="header-wrapper"><h2 id="x10-permissions-policy-integration"><bdi class="secno">10. </bdi>
+          Permissions Policy integration
+        </h2><a class="self-link" href="#permissions-policy" aria-label="Permalink for Section 10."></a></div>
+        
+        <p>
+          This specification defines a <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://www.w3.org/TR/permissions-policy-1/#policy-controlled-feature">policy-controlled feature</a> identified
+          by the string <dfn class="permission export" data-dfn-type="permission" data-export="" id="dfn-monetization" tabindex="0" aria-haspopup="dialog">"monetization"</dfn>. Its
+          default <a data-type="dfn" href="https://www.w3.org/TR/permissions-policy-1/#allowlist">allowlist</a> is <code>'self'</code>.
+        </p>
+        <div class="note" role="note" id="issue-container-generatedID-3"><div role="heading" class="note-title marker" id="h-note-1" aria-level="3"><span>Note</span></div><aside class="">
+          <p>
+            A <a data-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">document</a>'s <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy">permissions policy</a> determines
+            whether <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> elements are monetized - particularly in third-party
+            content, such as an <code><a data-link-type="element" data-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">iframe</a></code>. When disabled, monetization is
+            disabled and related events won't be dispatched.
+          </p>
+        </aside></div>
+        <div class="note" role="note" id="issue-container-generatedID-4"><div role="heading" class="note-title marker" id="h-note-2" aria-level="3"><span>Note</span></div><aside class="">
+          <p>The <a href="https://html.spec.whatwg.org/#attr-iframe-allow">allow</a> attributes only take effect when the content navigable of the iframe is navigated. Adding or removing the monetization attribute has no effect on an already-loaded document.</p>
+        </aside></div>
+      </section>
+      <section data-cite="CSP" id="content-security-policy"><div class="header-wrapper"><h2 id="x11-content-security-policy"><bdi class="secno">11. </bdi>
+          Content Security Policy
+        </h2><a class="self-link" href="#content-security-policy" aria-label="Permalink for Section 11."></a></div>
+        
+        <div class="note" role="note" id="issue-container-generatedID-5"><div role="heading" class="note-title marker" id="h-note-3" aria-level="3"><span>Note</span><span class="issue-label">: Monkey patch 🐒</span></div><p class="">
+          This section will eventually be moved into the [<cite><a class="bibref" data-link-type="biblio" href="#bib-csp" title="Content Security Policy Level 3">CSP</a></cite>] and [<cite><a class="bibref" data-link-type="biblio" href="#bib-fetch" title="Fetch Standard">FETCH</a></cite>]
+          specifications.
+        </p></div>
+        <section id="monetization-src-directive"><div class="header-wrapper"><h3 id="x11-1-monetization-src-directive"><bdi class="secno">11.1 </bdi>
+            <dfn class="export" data-export="" id="dfn-monetization-src" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">monetization-src</dfn> directive
+          </h3><a class="self-link" href="#monetization-src-directive" aria-label="Permalink for Section 11.1"></a></div>
+          
+          <p>
+            The monetization-src directive restricts the URLs from which a
+            <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-5">payment pointer</a> is loaded. The syntax for the directive's name
+            and value is described by the following ABNF:
+          </p>
+          <pre aria-busy="false"><code class="hljs abnf"><span class="hljs-attribute">directive-name</span>  = <span class="hljs-string">"monetization-src"</span>
+  <span class="hljs-attribute">directive-value</span> = serialized-source-list</code></pre>
+          <aside class="example" id="example-6"><div class="marker">
+      <a class="self-link" href="#example-6">Example<bdi> 6</bdi></a>
+    </div>
+            <p>
+              Given a page with the following Content Security Policy:
+            </p>
+            <pre class="http" aria-busy="false"><code class="hljs">Content-Security-Policy: monetization-src https://example.com/</code></pre>
+            <p>
+              Fetches for the following code will return a network errors, as the
+              URL provided do not match monetization-src's source list:
+            </p>
+            <pre aria-busy="false"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">link</span> <span class="hljs-attr">rel</span>=<span class="hljs-string">"monetization"</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"https://example.org/payment-pointer"</span>&gt;</span></code></pre>
+          </aside>
+          <section data-cite="CSP" id="monetization-src-pre-request-check"><div class="header-wrapper"><h4 id="x11-1-1-monetization-src-pre-request-check"><bdi class="secno">11.1.1 </bdi>
+              <code>monetization-src</code> Pre-request check
+            </h4><a class="self-link" href="#monetization-src-pre-request-check" aria-label="Permalink for Section 11.1.1"></a></div>
+            
+            <p>
+              This directive's pre-request check is as follows:
+            </p>
+            <p>
+              Given a <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://www.w3.org/TR/CSP3/#violation-policy">policy</a>
+              (<var>policy</var>):
+            </p>
+            <ol class="algorithm">
+              <li>Let <var>name</var> be the result of executing "Get the effective
+              directive for request" on <var>request</var>.
+              </li>
+              <li>If the result of executing "Should fetch directive execute" on
+              <var>name</var>, <code>monetization-src</code> and <var>policy</var> is "No", return "Allowed".
+              </li>
+              <li>If the result of executing "Does request match source list?" on
+              <var>request</var>, this directive's value, and <var>policy</var>, is "Does Not
+              Match", return "Blocked".
+              </li>
+              <li>Return "Allowed".
+              </li>
+            </ol>
+          </section>
+          <section id="monetization-src-post-request-check"><div class="header-wrapper"><h4 id="x11-1-2-monetization-src-post-request-check"><bdi class="secno">11.1.2 </bdi>
+              <code>monetization-src</code> Post-request check
+            </h4><a class="self-link" href="#monetization-src-post-request-check" aria-label="Permalink for Section 11.1.2"></a></div>
+            
+            <p>
+              This directive's post-request check is as follows:
+            </p>
+            <p>
+              Given a <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn|abstract-op" data-type="dfn" href="https://www.w3.org/TR/CSP3/#violation-policy">policy</a>
+              (<var>policy</var>):
+            </p>
+            <ol>
+              <li>Let <var>name</var> be the result of executing "Get the effective
+              directive for request" on <var>request</var>.
+              </li>
+              <li>If the result of executing "Should fetch directive execute" on
+              <var>name</var>, <code>monetization-src</code> and <var>policy</var> is "No", return "Allowed".
+              </li>
+              <li>If the result of executing "Does response to request match
+              source list?" on <var>response</var>, <var>request</var>, this directive's value, and
+              <var>policy</var>, is "Does Not Match", return "Blocked".
+              </li>
+              <li>Return "Allowed".
+              </li>
+            </ol>
+          </section>
+        </section>
+      </section>
+      <section id="security-considerations"><div class="header-wrapper"><h2 id="x12-security-considerations"><bdi class="secno">12. </bdi>
+          Security considerations
+        </h2><a class="self-link" href="#security-considerations" aria-label="Permalink for Section 12."></a></div>
+        
+        <p>
+          It is <em class="rfc2119">RECOMMENDED</em> that a user agent provide some UI or indicator that
+          allows the user to know when <a data-link-type="dfn|abstract-op" href="#dfn-monetized" class="internalDFN" id="ref-for-dfn-monetized-2">monetization</a> is possible and/or when
+          <a data-link-type="dfn|abstract-op" href="#dfn-monetized" class="internalDFN" id="ref-for-dfn-monetized-3">monetization</a> is occurring. Providing such a UI allows the users to
+          retain control of the monetization process by taking action (e.g., stop
+          or start monetization of a particular site if they wish to do so).
+        </p>
+        <p>
+          As <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-6">payment pointers</a> are generally provided as a service (e.g.,
+          Uphold), a <abbr title="Cross Site Scripting">XSS</abbr> attack could
+          inject malicious <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-7">payment pointers</a> into a page that uses the same
+          service. To mitigate such an attack, it is <em class="rfc2119">RECOMMENDED</em> that developers:
+        </p>
+        <ul>
+          <li>host a <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-8">payment pointer</a> on their own servers and proxy [<cite><a class="bibref" data-link-type="biblio" href="#bib-open payments" title="Open Payments">Open Payments</a></cite>] requests on the server as needed.
+          </li>
+          <li>Set the <code>monetization-src</code> CSP directive to restrict requests to
+          origins they control and trust to host <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-9">payment pointers</a>.
+          </li>
+        </ul>
+      </section>
+      <section id="privacy-considerations"><div class="header-wrapper"><h2 id="x13-privacy-considerations"><bdi class="secno">13. </bdi>
+          Privacy considerations
+        </h2><a class="self-link" href="#privacy-considerations" aria-label="Permalink for Section 13."></a></div>
+        
+        <p>
+          Web Monetization is designed to be privacy-preserving: The user agent
+          does not send any data to the <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-5">monetization provider</a>. Instead, it
+          requests data from the <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-6">monetization provider</a> without ever revealing
+          the URL of the web page the user is currently browsing.
+        </p>
+        <p>
+          Further, the user agent gets the payment information from the <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-10">payment pointer</a> to establish the <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-8">payment session</a>. This also ensures the
+          <a data-link-type="dfn|abstract-op" href="#dfn-provider" class="internalDFN" id="ref-for-dfn-provider-7">monetization provider</a> doesn't have access to a user's browsing
+          history or to the <a data-link-type="dfn|abstract-op" href="#dfn-payment-pointer" class="internalDFN" id="ref-for-dfn-payment-pointer-11">payment pointer</a>.
+        </p>
+      </section>
+      <section id="relation-to-other-technologies" class="informative"><div class="header-wrapper"><h2 id="x14-relation-to-web-payments"><bdi class="secno">14. </bdi>
+          Relation to Web Payments
+        </h2><a class="self-link" href="#relation-to-other-technologies" aria-label="Permalink for Section 14."></a></div><p><em>This section is non-normative.</em></p>
+        
+        <p>
+          Unlike <cite><a data-matched-text="[[[Payment-Request]]]" href="https://www.w3.org/TR/payment-request/">Payment Request API</a></cite> and the <cite><a data-matched-text="[[[Payment-Handler]]]" href="https://www.w3.org/TR/payment-handler/">Payment Handler API</a></cite>, which only
+          supports "one-off" payments, Web Monetization provides a <a data-link-type="dfn|abstract-op" href="#dfn-payment-session" class="internalDFN" id="ref-for-dfn-payment-session-9">payment session</a> that supports both continuous payments and "one-off"
+          payments.
+        </p>
+      </section>
+      <section id="conformance" class="appendix"><div class="header-wrapper"><h2 id="a-conformance"><bdi class="secno">A. </bdi>Conformance</h2><a class="self-link" href="#conformance" aria-label="Permalink for Appendix A."></a></div><p>As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.</p><p>
+          The key words <em class="rfc2119">MUST</em>, <em class="rfc2119">MUST NOT</em>, and <em class="rfc2119">RECOMMENDED</em> in this document
+          are to be interpreted as described in
+          <a href="https://datatracker.ietf.org/doc/html/bcp14">BCP 14</a>
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8174" title="Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words">RFC8174</a></cite>]
+          when, and only when, they appear in all capitals, as shown here.
+        </p></section>
     
-    <dl class="bibliography"><dt id="bib-csp">[CSP]</dt><dd>
-      <a href="https://www.w3.org/TR/CSP3/"><cite>Content Security Policy Level 3</cite></a>. Mike West; Antonio Sartori.  W3C. 28 June 2023. W3C Working Draft. URL: <a href="https://www.w3.org/TR/CSP3/">https://www.w3.org/TR/CSP3/</a>
-    </dd><dt id="bib-dom">[dom]</dt><dd>
-      <a href="https://dom.spec.whatwg.org/"><cite>DOM Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
-    </dd><dt id="bib-fetch">[FETCH]</dt><dd>
-      <a href="https://fetch.spec.whatwg.org/"><cite>Fetch Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
-    </dd><dt id="bib-html">[HTML]</dt><dd>
-      <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Anne van Kesteren; Domenic Denicola; Ian Hickson; Philip Jägenstedt; Simon Pieters.  WHATWG. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
-    </dd><dt id="bib-infra">[infra]</dt><dd>
-      <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Anne van Kesteren; Domenic Denicola.  WHATWG. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
-    </dd><dt id="bib-interledger">[Interledger]</dt><dd>
-      <a href="https://interledger.org/rfcs/0027-interledger-protocol-4/"><cite>Interledger Protocol</cite></a>. URL: <a href="https://interledger.org/rfcs/0027-interledger-protocol-4/">https://interledger.org/rfcs/0027-interledger-protocol-4/</a>
-    </dd><dt id="bib-open payments">[Open Payments]</dt><dd>
-      <a href="https://docs.openpayments.guide/"><cite>Open Payments</cite></a>. URL: <a href="https://docs.openpayments.guide/">https://docs.openpayments.guide/</a>
-    </dd><dt id="bib-payment-request">[payment-request]</dt><dd>
-      <a href="https://www.w3.org/TR/payment-request/"><cite>Payment Request API</cite></a>. Marcos Caceres; Rouslan Solomakhin; Ian Jacobs.  W3C. 8 September 2022. W3C Recommendation. URL: <a href="https://www.w3.org/TR/payment-request/">https://www.w3.org/TR/payment-request/</a>
-    </dd><dt id="bib-permissions-policy">[permissions-policy]</dt><dd>
-      <a href="https://www.w3.org/TR/permissions-policy-1/"><cite>Permissions Policy</cite></a>. Ian Clelland.  W3C. 30 June 2023. W3C Working Draft. URL: <a href="https://www.w3.org/TR/permissions-policy-1/">https://www.w3.org/TR/permissions-policy-1/</a>
-    </dd><dt id="bib-receipt">[Receipt]</dt><dd>
-      <a href="https://interledger.org/rfcs/0039-stream-receipts/"><cite>STREAM Receipt</cite></a>. URL: <a href="https://interledger.org/rfcs/0039-stream-receipts/">https://interledger.org/rfcs/0039-stream-receipts/</a>
-    </dd><dt id="bib-rfc2119">[RFC2119]</dt><dd>
-      <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
-    </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
-      <a href="https://www.rfc-editor.org/rfc/rfc8174"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc8174">https://www.rfc-editor.org/rfc/rfc8174</a>
-    </dd><dt id="bib-stream">[STREAM]</dt><dd>
-      <a href="https://interledger.org/rfcs/0029-stream/"><cite>STREAM</cite></a>. URL: <a href="https://interledger.org/rfcs/0029-stream/">https://interledger.org/rfcs/0029-stream/</a>
-    </dd><dt id="bib-url">[url]</dt><dd>
-      <a href="https://url.spec.whatwg.org/"><cite>URL Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
-    </dd><dt id="bib-webidl">[webidl]</dt><dd>
-      <a href="https://webidl.spec.whatwg.org/"><cite>Web IDL Standard</cite></a>. Edgar Chen; Timothy Gu.  WHATWG. Living Standard. URL: <a href="https://webidl.spec.whatwg.org/">https://webidl.spec.whatwg.org/</a>
-    </dd></dl>
-  </section><section id="informative-references"><div class="header-wrapper"><h3 id="b-2-informative-references"><bdi class="secno">B.2 </bdi>Informative references</h3><a class="self-link" href="#informative-references" aria-label="Permalink for Appendix B.2"></a></div>
-    
-    <dl class="bibliography"><dt id="bib-payment-handler">[Payment-Handler]</dt><dd>
-      <a href="https://www.w3.org/TR/payment-handler/"><cite>Payment Handler API</cite></a>. Adrian Hope-Bailie; Ian Jacobs; Rouslan Solomakhin; Jinho Bang.  W3C. 25 January 2023. W3C Working Draft. URL: <a href="https://www.w3.org/TR/payment-handler/">https://www.w3.org/TR/payment-handler/</a>
-    </dd></dl>
-  </section></section><p role="navigation" id="back-to-top">
-    <a href="#title"><abbr title="Back to Top">↑</abbr></a>
-  </p><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-monetized" aria-label="Links in this document to definition: Monetization">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dfn-monetized" aria-label="Permalink for definition: Monetization. Activate to close this dialog.">Permalink</a>
-         
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dfn-monetized-1" title="§ 5. onmonetization event handler">§ 5. onmonetization event handler</a> 
-  </li><li>
-    <a href="#ref-for-dfn-monetized-2" title="§ 12. Security considerations">§ 12. Security considerations</a> <a href="#ref-for-dfn-monetized-3" title="Reference 2">(2)</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-provider" aria-label="Links in this document to definition: Monetization provider">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dfn-provider" aria-label="Permalink for definition: Monetization provider. Activate to close this dialog.">Permalink</a>
-         
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dfn-provider-1" title="§ 2. Model">§ 2. Model</a> <a href="#ref-for-dfn-provider-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-provider-3" title="Reference 3">(3)</a> 
-  </li><li>
-    <a href="#ref-for-dfn-provider-4" title="§ 9.5 receipt attribute (deprecated)">§ 9.5 receipt attribute (deprecated)</a> 
-  </li><li>
-    <a href="#ref-for-dfn-provider-5" title="§ 13. Privacy considerations">§ 13. Privacy considerations</a> <a href="#ref-for-dfn-provider-6" title="Reference 2">(2)</a> <a href="#ref-for-dfn-provider-7" title="Reference 3">(3)</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-monetization-receiver" aria-label="Links in this document to definition: Monetization receiver">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dfn-monetization-receiver" aria-label="Permalink for definition: Monetization receiver. Activate to close this dialog.">Permalink</a>
-         
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dfn-monetization-receiver-1" title="§ 1.3 Monetization events">§ 1.3 Monetization events</a> 
-  </li><li>
-    <a href="#ref-for-dfn-monetization-receiver-2" title="§ 1.4 Verifying a payment">§ 1.4 Verifying a payment</a> <a href="#ref-for-dfn-monetization-receiver-3" title="Reference 2">(2)</a> 
-  </li><li>
-    <a href="#ref-for-dfn-monetization-receiver-4" title="§ 2. Model">§ 2. Model</a> <a href="#ref-for-dfn-monetization-receiver-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-monetization-receiver-6" title="Reference 3">(3)</a> 
-  </li><li>
-    <a href="#ref-for-dfn-monetization-receiver-7" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
-  </li><li>
-    <a href="#ref-for-dfn-monetization-receiver-8" title="§ 9.1 amount attribute (deprecated)">§ 9.1 amount attribute (deprecated)</a> 
-  </li><li>
-    <a href="#ref-for-dfn-monetization-receiver-9" title="§ 9.5 receipt attribute (deprecated)">§ 9.5 receipt attribute (deprecated)</a> 
-  </li><li>
-    <a href="#ref-for-dfn-monetization-receiver-10" title="§ 9.7 incomingPayment attribute">§ 9.7 incomingPayment attribute</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-payment-pointer" aria-label="Links in this document to definition: Payment Pointer">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dfn-payment-pointer" aria-label="Permalink for definition: Payment Pointer. Activate to close this dialog.">Permalink</a>
-         
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dfn-payment-pointer-1" title="§ 1.5 Monetizing media">§ 1.5 Monetizing media</a> 
-  </li><li>
-    <a href="#ref-for-dfn-payment-pointer-2" title="§ 2. Model">§ 2. Model</a> 
-  </li><li>
-    <a href="#ref-for-dfn-payment-pointer-3" title="§ 4. Link type &quot;monetization&quot;">§ 4. Link type "monetization"</a> 
-  </li><li>
-    <a href="#ref-for-dfn-payment-pointer-4" title="§ 9.6 paymentPointer attribute">§ 9.6 paymentPointer attribute</a> 
-  </li><li>
-    <a href="#ref-for-dfn-payment-pointer-5" title="§ 11.1 monetization-src directive">§ 11.1 monetization-src directive</a> 
-  </li><li>
-    <a href="#ref-for-dfn-payment-pointer-6" title="§ 12. Security considerations">§ 12. Security considerations</a> <a href="#ref-for-dfn-payment-pointer-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-payment-pointer-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-payment-pointer-9" title="Reference 4">(4)</a> 
-  </li><li>
-    <a href="#ref-for-dfn-payment-pointer-10" title="§ 13. Privacy considerations">§ 13. Privacy considerations</a> <a href="#ref-for-dfn-payment-pointer-11" title="Reference 2">(2)</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-payment-session" aria-label="Links in this document to definition: Payment session">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dfn-payment-session" aria-label="Permalink for definition: Payment session. Activate to close this dialog.">Permalink</a>
-         
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dfn-payment-session-1" title="§ 4. Link type &quot;monetization&quot;">§ 4. Link type "monetization"</a> <a href="#ref-for-dfn-payment-session-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-payment-session-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-payment-session-4" title="Reference 4">(4)</a> 
-  </li><li>
-    <a href="#ref-for-dfn-payment-session-5" title="§ 6. monetization event">§ 6. monetization event</a> <a href="#ref-for-dfn-payment-session-6" title="Reference 2">(2)</a> 
-  </li><li>
-    <a href="#ref-for-dfn-payment-session-7" title="§ 9.5 receipt attribute (deprecated)">§ 9.5 receipt attribute (deprecated)</a> 
-  </li><li>
-    <a href="#ref-for-dfn-payment-session-8" title="§ 13. Privacy considerations">§ 13. Privacy considerations</a> 
-  </li><li>
-    <a href="#ref-for-dfn-payment-session-9" title="§ 14. Relation to Web Payments">§ 14. Relation to Web Payments</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-monetization-task-source" aria-label="Links in this document to definition: monetization task source">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dfn-monetization-task-source" aria-label="Permalink for definition: monetization task source. Activate to close this dialog.">Permalink</a>
-         
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dfn-monetization-task-source-1" title="§ 6. monetization event">§ 6. monetization event</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationcurrencyamount" aria-label="Links in this document to definition: MonetizationCurrencyAmount">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationcurrencyamount" aria-label="Permalink for definition: MonetizationCurrencyAmount. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dom-monetizationcurrencyamount-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationcurrencyamount-currency" aria-label="Links in this document to definition: currency">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationcurrencyamount-currency" aria-label="Permalink for definition: currency. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-385319265">IDL</a>
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dom-monetizationcurrencyamount-currency-1" title="§ 8. MonetizationCurrencyAmount interface">§ 8. MonetizationCurrencyAmount interface</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationcurrencyamount-value" aria-label="Links in this document to definition: value">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationcurrencyamount-value" aria-label="Permalink for definition: value. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-385319265">IDL</a>
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dom-monetizationcurrencyamount-value-1" title="§ 8. MonetizationCurrencyAmount interface">§ 8. MonetizationCurrencyAmount interface</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent" aria-label="Links in this document to definition: MonetizationEvent">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationevent" aria-label="Permalink for definition: MonetizationEvent. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dom-monetizationevent-1" title="§ 1.1 Checking if Web Monetization is supported">§ 1.1 Checking if Web Monetization is supported</a> 
-  </li><li>
-    <a href="#ref-for-dom-monetizationevent-2" title="§ 1.3 Monetization events">§ 1.3 Monetization events</a> <a href="#ref-for-dom-monetizationevent-3" title="Reference 2">(2)</a> 
-  </li><li>
-    <a href="#ref-for-dom-monetizationevent-4" title="§ 1.4 Verifying a payment">§ 1.4 Verifying a payment</a> <a href="#ref-for-dom-monetizationevent-5" title="Reference 2">(2)</a> 
-  </li><li>
-    <a href="#ref-for-dom-monetizationevent-6" title="§ 6. monetization event">§ 6. monetization event</a> 
-  </li><li>
-    <a href="#ref-for-dom-monetizationevent-7" title="§ 7. Task sources">§ 7. Task sources</a> 
-  </li><li>
-    <a href="#ref-for-dom-monetizationevent-8" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-constructor" aria-label="Links in this document to definition: constructor">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationevent-constructor" aria-label="Permalink for definition: constructor. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-      <li>Not referenced in this document.</li>
+  
+  <section id="references" class="appendix"><div class="header-wrapper"><h2 id="b-references"><bdi class="secno">B. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix B."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="b-1-normative-references"><bdi class="secno">B.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix B.1"></a></div>
+      
+      <dl class="bibliography"><dt id="bib-csp">[CSP]</dt><dd>
+        <a href="https://www.w3.org/TR/CSP3/"><cite>Content Security Policy Level 3</cite></a>. Mike West; Antonio Sartori.  W3C. 28 June 2023. W3C Working Draft. URL: <a href="https://www.w3.org/TR/CSP3/">https://www.w3.org/TR/CSP3/</a>
+      </dd><dt id="bib-dom">[dom]</dt><dd>
+        <a href="https://dom.spec.whatwg.org/"><cite>DOM Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
+      </dd><dt id="bib-fetch">[FETCH]</dt><dd>
+        <a href="https://fetch.spec.whatwg.org/"><cite>Fetch Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+      </dd><dt id="bib-html">[HTML]</dt><dd>
+        <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Anne van Kesteren; Domenic Denicola; Ian Hickson; Philip Jägenstedt; Simon Pieters.  WHATWG. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+      </dd><dt id="bib-infra">[infra]</dt><dd>
+        <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Anne van Kesteren; Domenic Denicola.  WHATWG. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+      </dd><dt id="bib-interledger">[Interledger]</dt><dd>
+        <a href="https://interledger.org/rfcs/0027-interledger-protocol-4/"><cite>Interledger Protocol</cite></a>. URL: <a href="https://interledger.org/rfcs/0027-interledger-protocol-4/">https://interledger.org/rfcs/0027-interledger-protocol-4/</a>
+      </dd><dt id="bib-open payments">[Open Payments]</dt><dd>
+        <a href="https://docs.openpayments.guide/"><cite>Open Payments</cite></a>. URL: <a href="https://docs.openpayments.guide/">https://docs.openpayments.guide/</a>
+      </dd><dt id="bib-payment-request">[payment-request]</dt><dd>
+        <a href="https://www.w3.org/TR/payment-request/"><cite>Payment Request API</cite></a>. Marcos Caceres; Rouslan Solomakhin; Ian Jacobs.  W3C. 8 September 2022. W3C Recommendation. URL: <a href="https://www.w3.org/TR/payment-request/">https://www.w3.org/TR/payment-request/</a>
+      </dd><dt id="bib-permissions-policy">[permissions-policy]</dt><dd>
+        <a href="https://www.w3.org/TR/permissions-policy-1/"><cite>Permissions Policy</cite></a>. Ian Clelland.  W3C. 5 July 2023. W3C Working Draft. URL: <a href="https://www.w3.org/TR/permissions-policy-1/">https://www.w3.org/TR/permissions-policy-1/</a>
+      </dd><dt id="bib-receipt">[Receipt]</dt><dd>
+        <a href="https://interledger.org/rfcs/0039-stream-receipts/"><cite>STREAM Receipt</cite></a>. URL: <a href="https://interledger.org/rfcs/0039-stream-receipts/">https://interledger.org/rfcs/0039-stream-receipts/</a>
+      </dd><dt id="bib-rfc2119">[RFC2119]</dt><dd>
+        <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
+      </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
+        <a href="https://www.rfc-editor.org/rfc/rfc8174"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc8174">https://www.rfc-editor.org/rfc/rfc8174</a>
+      </dd><dt id="bib-stream">[STREAM]</dt><dd>
+        <a href="https://interledger.org/rfcs/0029-stream/"><cite>STREAM</cite></a>. URL: <a href="https://interledger.org/rfcs/0029-stream/">https://interledger.org/rfcs/0029-stream/</a>
+      </dd><dt id="bib-url">[url]</dt><dd>
+        <a href="https://url.spec.whatwg.org/"><cite>URL Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+      </dd><dt id="bib-webidl">[webidl]</dt><dd>
+        <a href="https://webidl.spec.whatwg.org/"><cite>Web IDL Standard</cite></a>. Edgar Chen; Timothy Gu.  WHATWG. Living Standard. URL: <a href="https://webidl.spec.whatwg.org/">https://webidl.spec.whatwg.org/</a>
+      </dd></dl>
+    </section><section id="informative-references"><div class="header-wrapper"><h3 id="b-2-informative-references"><bdi class="secno">B.2 </bdi>Informative references</h3><a class="self-link" href="#informative-references" aria-label="Permalink for Appendix B.2"></a></div>
+      
+      <dl class="bibliography"><dt id="bib-payment-handler">[Payment-Handler]</dt><dd>
+        <a href="https://www.w3.org/TR/payment-handler/"><cite>Payment Handler API</cite></a>. Adrian Hope-Bailie; Ian Jacobs; Rouslan Solomakhin; Jinho Bang.  W3C. 25 January 2023. W3C Working Draft. URL: <a href="https://www.w3.org/TR/payment-handler/">https://www.w3.org/TR/payment-handler/</a>
+      </dd></dl>
+    </section></section><p role="navigation" id="back-to-top">
+      <a href="#title"><abbr title="Back to Top">↑</abbr></a>
+    </p><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-monetized" aria-label="Links in this document to definition: Monetization">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dfn-monetized" aria-label="Permalink for definition: Monetization. Activate to close this dialog.">Permalink</a>
+           
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dfn-monetized-1" title="§ 5. onmonetization event handler">§ 5. onmonetization event handler</a> 
+    </li><li>
+      <a href="#ref-for-dfn-monetized-2" title="§ 12. Security considerations">§ 12. Security considerations</a> <a href="#ref-for-dfn-monetized-3" title="Reference 2">(2)</a> 
+    </li>
     </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit" aria-label="Links in this document to definition: MonetizationEventInit">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationeventinit" aria-label="Permalink for definition: MonetizationEventInit. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dom-monetizationeventinit-1" title="§ 6. monetization event">§ 6. monetization event</a> 
-  </li><li>
-    <a href="#ref-for-dom-monetizationeventinit-2" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-amount" aria-label="Links in this document to definition: amount">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationeventinit-amount" aria-label="Permalink for definition: amount. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-      <li>Not referenced in this document.</li>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-provider" aria-label="Links in this document to definition: Monetization provider">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dfn-provider" aria-label="Permalink for definition: Monetization provider. Activate to close this dialog.">Permalink</a>
+           
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dfn-provider-1" title="§ 2. Model">§ 2. Model</a> <a href="#ref-for-dfn-provider-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-provider-3" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-provider-4" title="§ 9.5 receipt attribute (deprecated)">§ 9.5 receipt attribute (deprecated)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-provider-5" title="§ 13. Privacy considerations">§ 13. Privacy considerations</a> <a href="#ref-for-dfn-provider-6" title="Reference 2">(2)</a> <a href="#ref-for-dfn-provider-7" title="Reference 3">(3)</a> 
+    </li>
     </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-assetcode" aria-label="Links in this document to definition: assetCode">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationeventinit-assetcode" aria-label="Permalink for definition: assetCode. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-      <li>Not referenced in this document.</li>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-monetization-receiver" aria-label="Links in this document to definition: Monetization receiver">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dfn-monetization-receiver" aria-label="Permalink for definition: Monetization receiver. Activate to close this dialog.">Permalink</a>
+           
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dfn-monetization-receiver-1" title="§ 1.3 Monetization events">§ 1.3 Monetization events</a> 
+    </li><li>
+      <a href="#ref-for-dfn-monetization-receiver-2" title="§ 1.4 Verifying a payment">§ 1.4 Verifying a payment</a> <a href="#ref-for-dfn-monetization-receiver-3" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-monetization-receiver-4" title="§ 2. Model">§ 2. Model</a> <a href="#ref-for-dfn-monetization-receiver-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-monetization-receiver-6" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-monetization-receiver-7" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
+    </li><li>
+      <a href="#ref-for-dfn-monetization-receiver-8" title="§ 9.1 amount attribute (deprecated)">§ 9.1 amount attribute (deprecated)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-monetization-receiver-9" title="§ 9.5 receipt attribute (deprecated)">§ 9.5 receipt attribute (deprecated)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-monetization-receiver-10" title="§ 9.7 incomingPayment attribute">§ 9.7 incomingPayment attribute</a> 
+    </li>
     </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-assetscale" aria-label="Links in this document to definition: assetScale">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationeventinit-assetscale" aria-label="Permalink for definition: assetScale. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-      <li>Not referenced in this document.</li>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-payment-pointer" aria-label="Links in this document to definition: Payment Pointer">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dfn-payment-pointer" aria-label="Permalink for definition: Payment Pointer. Activate to close this dialog.">Permalink</a>
+           
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dfn-payment-pointer-1" title="§ 1.5 Monetizing media">§ 1.5 Monetizing media</a> 
+    </li><li>
+      <a href="#ref-for-dfn-payment-pointer-2" title="§ 2. Model">§ 2. Model</a> 
+    </li><li>
+      <a href="#ref-for-dfn-payment-pointer-3" title="§ 4. Link type &quot;monetization&quot;">§ 4. Link type "monetization"</a> 
+    </li><li>
+      <a href="#ref-for-dfn-payment-pointer-4" title="§ 9.6 paymentPointer attribute">§ 9.6 paymentPointer attribute</a> 
+    </li><li>
+      <a href="#ref-for-dfn-payment-pointer-5" title="§ 11.1 monetization-src directive">§ 11.1 monetization-src directive</a> 
+    </li><li>
+      <a href="#ref-for-dfn-payment-pointer-6" title="§ 12. Security considerations">§ 12. Security considerations</a> <a href="#ref-for-dfn-payment-pointer-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-payment-pointer-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-payment-pointer-9" title="Reference 4">(4)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-payment-pointer-10" title="§ 13. Privacy considerations">§ 13. Privacy considerations</a> <a href="#ref-for-dfn-payment-pointer-11" title="Reference 2">(2)</a> 
+    </li>
     </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-receipt" aria-label="Links in this document to definition: receipt">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationeventinit-receipt" aria-label="Permalink for definition: receipt. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-      <li>Not referenced in this document.</li>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-payment-session" aria-label="Links in this document to definition: Payment session">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dfn-payment-session" aria-label="Permalink for definition: Payment session. Activate to close this dialog.">Permalink</a>
+           
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dfn-payment-session-1" title="§ 4. Link type &quot;monetization&quot;">§ 4. Link type "monetization"</a> <a href="#ref-for-dfn-payment-session-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-payment-session-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-payment-session-4" title="Reference 4">(4)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-payment-session-5" title="§ 6. monetization event">§ 6. monetization event</a> <a href="#ref-for-dfn-payment-session-6" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-payment-session-7" title="§ 9.5 receipt attribute (deprecated)">§ 9.5 receipt attribute (deprecated)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-payment-session-8" title="§ 13. Privacy considerations">§ 13. Privacy considerations</a> 
+    </li><li>
+      <a href="#ref-for-dfn-payment-session-9" title="§ 14. Relation to Web Payments">§ 14. Relation to Web Payments</a> 
+    </li>
     </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-amountsent" aria-label="Links in this document to definition: amountSent">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationeventinit-amountsent" aria-label="Permalink for definition: amountSent. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-      <li>Not referenced in this document.</li>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-monetization-task-source" aria-label="Links in this document to definition: monetization task source">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dfn-monetization-task-source" aria-label="Permalink for definition: monetization task source. Activate to close this dialog.">Permalink</a>
+           
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dfn-monetization-task-source-1" title="§ 6. monetization event">§ 6. monetization event</a> 
+    </li>
     </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-paymentpointer" aria-label="Links in this document to definition: paymentPointer">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationeventinit-paymentpointer" aria-label="Permalink for definition: paymentPointer. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-      <li>Not referenced in this document.</li>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationcurrencyamount" aria-label="Links in this document to definition: MonetizationCurrencyAmount">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationcurrencyamount" aria-label="Permalink for definition: MonetizationCurrencyAmount. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dom-monetizationcurrencyamount-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
+    </li>
     </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-incomingpayment" aria-label="Links in this document to definition: incomingPayment">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationeventinit-incomingpayment" aria-label="Permalink for definition: incomingPayment. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-      <li>Not referenced in this document.</li>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationcurrencyamount-currency" aria-label="Links in this document to definition: currency">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationcurrencyamount-currency" aria-label="Permalink for definition: currency. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-385319265">IDL</a>
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dom-monetizationcurrencyamount-currency-1" title="§ 8. MonetizationCurrencyAmount interface">§ 8. MonetizationCurrencyAmount interface</a> 
+    </li>
     </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-amount" aria-label="Links in this document to definition: amount">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationevent-amount" aria-label="Permalink for definition: amount. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dom-monetizationevent-amount-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-assetcode" aria-label="Links in this document to definition: assetCode">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationevent-assetcode" aria-label="Permalink for definition: assetCode. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dom-monetizationevent-assetcode-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-assetscale" aria-label="Links in this document to definition: assetScale">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationevent-assetscale" aria-label="Permalink for definition: assetScale. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dom-monetizationevent-assetscale-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-amountsent" aria-label="Links in this document to definition: amountSent">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationevent-amountsent" aria-label="Permalink for definition: amountSent. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dom-monetizationevent-amountsent-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-receipt" aria-label="Links in this document to definition: receipt">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationevent-receipt" aria-label="Permalink for definition: receipt. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dom-monetizationevent-receipt-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-paymentpointer" aria-label="Links in this document to definition: paymentPointer">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationevent-paymentpointer" aria-label="Permalink for definition: paymentPointer. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dom-monetizationevent-paymentpointer-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-incomingpayment" aria-label="Links in this document to definition: incomingPayment">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dom-monetizationevent-incomingpayment" aria-label="Permalink for definition: incomingPayment. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-    <li>
-    <a href="#ref-for-dom-monetizationevent-incomingpayment-1" title="§ 1.4 Verifying a payment">§ 1.4 Verifying a payment</a> <a href="#ref-for-dom-monetizationevent-incomingpayment-2" title="Reference 2">(2)</a> <a href="#ref-for-dom-monetizationevent-incomingpayment-3" title="Reference 3">(3)</a> 
-  </li><li>
-    <a href="#ref-for-dom-monetizationevent-incomingpayment-4" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> <a href="#ref-for-dom-monetizationevent-incomingpayment-5" title="Reference 2">(2)</a> 
-  </li>
-  </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-monetization" aria-label="Links in this document to definition: &quot;monetization&quot;">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dfn-monetization" aria-label="Permalink for definition: &quot;monetization&quot;. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-      <li>Not referenced in this document.</li>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationcurrencyamount-value" aria-label="Links in this document to definition: value">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationcurrencyamount-value" aria-label="Permalink for definition: value. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-385319265">IDL</a>
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dom-monetizationcurrencyamount-value-1" title="§ 8. MonetizationCurrencyAmount interface">§ 8. MonetizationCurrencyAmount interface</a> 
+    </li>
     </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-monetization-src" aria-label="Links in this document to definition: monetization-src">
-      <span class="caret"></span>
-      <div>
-        <a class="self-link" href="#dfn-monetization-src" aria-label="Permalink for definition: monetization-src. Activate to close this dialog.">Permalink</a>
-        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
-      </div>
-      <p><b>Referenced in:</b></p>
-      <ul>
-      <li>Not referenced in this document.</li>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent" aria-label="Links in this document to definition: MonetizationEvent">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationevent" aria-label="Permalink for definition: MonetizationEvent. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dom-monetizationevent-1" title="§ 1.1 Checking if Web Monetization is supported">§ 1.1 Checking if Web Monetization is supported</a> 
+    </li><li>
+      <a href="#ref-for-dom-monetizationevent-2" title="§ 1.3 Monetization events">§ 1.3 Monetization events</a> <a href="#ref-for-dom-monetizationevent-3" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dom-monetizationevent-4" title="§ 1.4 Verifying a payment">§ 1.4 Verifying a payment</a> <a href="#ref-for-dom-monetizationevent-5" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dom-monetizationevent-6" title="§ 6. monetization event">§ 6. monetization event</a> 
+    </li><li>
+      <a href="#ref-for-dom-monetizationevent-7" title="§ 7. Task sources">§ 7. Task sources</a> 
+    </li><li>
+      <a href="#ref-for-dom-monetizationevent-8" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
+    </li>
     </ul>
-    </div><script id="respec-dfn-panel">(() => {
-// @ts-check
-if (document.respec) {
-  document.respec.ready.then(setupPanel);
-} else {
-  setupPanel();
-}
-
-function setupPanel() {
-  const listener = panelListener();
-  document.body.addEventListener("keydown", listener);
-  document.body.addEventListener("click", listener);
-}
-
-function panelListener() {
-  /** @type {HTMLElement} */
-  let panel = null;
-  return event => {
-    const { target, type } = event;
-
-    if (!(target instanceof HTMLElement)) return;
-
-    // For keys, we only care about Enter key to activate the panel
-    // otherwise it's activated via a click.
-    if (type === "keydown" && event.key !== "Enter") return;
-
-    const action = deriveAction(event);
-
-    switch (action) {
-      case "show": {
-        hidePanel(panel);
-        /** @type {HTMLElement} */
-        const dfn = target.closest("dfn, .index-term");
-        panel = document.getElementById(`dfn-panel-for-${dfn.id}`);
-        const coords = deriveCoordinates(event);
-        displayPanel(dfn, panel, coords);
-        break;
-      }
-      case "dock": {
-        panel.style.left = null;
-        panel.style.top = null;
-        panel.classList.add("docked");
-        break;
-      }
-      case "hide": {
-        hidePanel(panel);
-        panel = null;
-        break;
-      }
-    }
-  };
-}
-
-/**
- * @param {MouseEvent|KeyboardEvent} event
- */
-function deriveCoordinates(event) {
-  const target = /** @type HTMLElement */ (event.target);
-
-  // We prevent synthetic AT clicks from putting
-  // the dialog in a weird place. The AT events sometimes
-  // lack coordinates, so they have clientX/Y = 0
-  const rect = target.getBoundingClientRect();
-  if (
-    event instanceof MouseEvent &&
-    event.clientX >= rect.left &&
-    event.clientY >= rect.top
-  ) {
-    // The event probably happened inside the bounding rect...
-    return { x: event.clientX, y: event.clientY };
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-constructor" aria-label="Links in this document to definition: constructor">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationevent-constructor" aria-label="Permalink for definition: constructor. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+        <li>Not referenced in this document.</li>
+      </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit" aria-label="Links in this document to definition: MonetizationEventInit">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationeventinit" aria-label="Permalink for definition: MonetizationEventInit. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dom-monetizationeventinit-1" title="§ 6. monetization event">§ 6. monetization event</a> 
+    </li><li>
+      <a href="#ref-for-dom-monetizationeventinit-2" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
+    </li>
+    </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-amount" aria-label="Links in this document to definition: amount">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationeventinit-amount" aria-label="Permalink for definition: amount. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+        <li>Not referenced in this document.</li>
+      </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-assetcode" aria-label="Links in this document to definition: assetCode">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationeventinit-assetcode" aria-label="Permalink for definition: assetCode. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+        <li>Not referenced in this document.</li>
+      </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-assetscale" aria-label="Links in this document to definition: assetScale">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationeventinit-assetscale" aria-label="Permalink for definition: assetScale. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+        <li>Not referenced in this document.</li>
+      </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-receipt" aria-label="Links in this document to definition: receipt">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationeventinit-receipt" aria-label="Permalink for definition: receipt. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+        <li>Not referenced in this document.</li>
+      </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-amountsent" aria-label="Links in this document to definition: amountSent">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationeventinit-amountsent" aria-label="Permalink for definition: amountSent. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+        <li>Not referenced in this document.</li>
+      </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-paymentpointer" aria-label="Links in this document to definition: paymentPointer">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationeventinit-paymentpointer" aria-label="Permalink for definition: paymentPointer. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+        <li>Not referenced in this document.</li>
+      </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationeventinit-incomingpayment" aria-label="Links in this document to definition: incomingPayment">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationeventinit-incomingpayment" aria-label="Permalink for definition: incomingPayment. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+        <li>Not referenced in this document.</li>
+      </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-amount" aria-label="Links in this document to definition: amount">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationevent-amount" aria-label="Permalink for definition: amount. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dom-monetizationevent-amount-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
+    </li>
+    </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-assetcode" aria-label="Links in this document to definition: assetCode">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationevent-assetcode" aria-label="Permalink for definition: assetCode. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dom-monetizationevent-assetcode-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
+    </li>
+    </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-assetscale" aria-label="Links in this document to definition: assetScale">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationevent-assetscale" aria-label="Permalink for definition: assetScale. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dom-monetizationevent-assetscale-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
+    </li>
+    </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-amountsent" aria-label="Links in this document to definition: amountSent">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationevent-amountsent" aria-label="Permalink for definition: amountSent. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dom-monetizationevent-amountsent-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
+    </li>
+    </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-receipt" aria-label="Links in this document to definition: receipt">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationevent-receipt" aria-label="Permalink for definition: receipt. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dom-monetizationevent-receipt-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
+    </li>
+    </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-paymentpointer" aria-label="Links in this document to definition: paymentPointer">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationevent-paymentpointer" aria-label="Permalink for definition: paymentPointer. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dom-monetizationevent-paymentpointer-1" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> 
+    </li>
+    </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-monetizationevent-incomingpayment" aria-label="Links in this document to definition: incomingPayment">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dom-monetizationevent-incomingpayment" aria-label="Permalink for definition: incomingPayment. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-106886564">IDL</a>
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+      <li>
+      <a href="#ref-for-dom-monetizationevent-incomingpayment-1" title="§ 1.4 Verifying a payment">§ 1.4 Verifying a payment</a> <a href="#ref-for-dom-monetizationevent-incomingpayment-2" title="Reference 2">(2)</a> <a href="#ref-for-dom-monetizationevent-incomingpayment-3" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dom-monetizationevent-incomingpayment-4" title="§ 9. MonetizationEvent interface">§ 9. MonetizationEvent interface</a> <a href="#ref-for-dom-monetizationevent-incomingpayment-5" title="Reference 2">(2)</a> 
+    </li>
+    </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-monetization" aria-label="Links in this document to definition: &quot;monetization&quot;">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dfn-monetization" aria-label="Permalink for definition: &quot;monetization&quot;. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+        <li>Not referenced in this document.</li>
+      </ul>
+      </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-monetization-src" aria-label="Links in this document to definition: monetization-src">
+        <span class="caret"></span>
+        <div>
+          <a class="self-link" href="#dfn-monetization-src" aria-label="Permalink for definition: monetization-src. Activate to close this dialog.">Permalink</a>
+          <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> 
+        </div>
+        <p><b>Referenced in:</b></p>
+        <ul>
+        <li>Not referenced in this document.</li>
+      </ul>
+      </div><script id="respec-dfn-panel">(() => {
+  // @ts-check
+  if (document.respec) {
+    document.respec.ready.then(setupPanel);
+  } else {
+    setupPanel();
   }
-
-  // Offset to the middle of the element
-  const x = rect.x + rect.width / 2;
-  // Placed at the bottom of the element
-  const y = rect.y + rect.height;
-  return { x, y };
-}
-
-/**
- * @param {Event} event
- */
-function deriveAction(event) {
-  const target = /** @type {HTMLElement} */ (event.target);
-  const hitALink = !!target.closest("a");
-  if (target.closest("dfn:not([data-cite]), .index-term")) {
-    return hitALink ? "none" : "show";
+  
+  function setupPanel() {
+    const listener = panelListener();
+    document.body.addEventListener("keydown", listener);
+    document.body.addEventListener("click", listener);
   }
-  if (target.closest(".dfn-panel")) {
-    if (hitALink) {
-      return target.classList.contains("self-link") ? "hide" : "dock";
-    }
-    const panel = target.closest(".dfn-panel");
-    return panel.classList.contains("docked") ? "hide" : "none";
-  }
-  if (document.querySelector(".dfn-panel:not([hidden])")) {
-    return "hide";
-  }
-  return "none";
-}
-
-/**
- * @param {HTMLElement} dfn
- * @param {HTMLElement} panel
- * @param {{ x: number, y: number }} clickPosition
- */
-function displayPanel(dfn, panel, { x, y }) {
-  panel.hidden = false;
-  // distance (px) between edge of panel and the pointing triangle (caret)
-  const MARGIN = 20;
-
-  const dfnRects = dfn.getClientRects();
-  // Find the `top` offset when the `dfn` can be spread across multiple lines
-  let closestTop = 0;
-  let minDiff = Infinity;
-  for (const rect of dfnRects) {
-    const { top, bottom } = rect;
-    const diffFromClickY = Math.abs((top + bottom) / 2 - y);
-    if (diffFromClickY < minDiff) {
-      minDiff = diffFromClickY;
-      closestTop = top;
-    }
-  }
-
-  const top = window.scrollY + closestTop + dfnRects[0].height;
-  const left = x - MARGIN;
-  panel.style.left = `${left}px`;
-  panel.style.top = `${top}px`;
-
-  // Find if the panel is flowing out of the window
-  const panelRect = panel.getBoundingClientRect();
-  const SCREEN_WIDTH = Math.min(window.innerWidth, window.screen.width);
-  if (panelRect.right > SCREEN_WIDTH) {
-    const newLeft = Math.max(MARGIN, x + MARGIN - panelRect.width);
-    const newCaretOffset = left - newLeft;
-    panel.style.left = `${newLeft}px`;
+  
+  function panelListener() {
     /** @type {HTMLElement} */
-    const caret = panel.querySelector(".caret");
-    caret.style.left = `${newCaretOffset}px`;
-  }
-
-  // As it's a dialog, we trap focus.
-  // TODO: when <dialog> becomes a implemented, we should really
-  // use that.
-  trapFocus(panel, dfn);
-}
-
-/**
- * @param {HTMLElement} panel
- * @param {HTMLElement} dfn
- * @returns
- */
-function trapFocus(panel, dfn) {
-  /** @type NodeListOf<HTMLAnchorElement> elements */
-  const anchors = panel.querySelectorAll("a[href]");
-  // No need to trap focus
-  if (!anchors.length) return;
-
-  // Move focus to first anchor element
-  const first = anchors.item(0);
-  first.focus();
-
-  const trapListener = createTrapListener(anchors, panel, dfn);
-  panel.addEventListener("keydown", trapListener);
-
-  // Hiding the panel releases the trap
-  const mo = new MutationObserver(records => {
-    const [record] = records;
-    const target = /** @type HTMLElement */ (record.target);
-    if (target.hidden) {
-      panel.removeEventListener("keydown", trapListener);
-      mo.disconnect();
-    }
-  });
-  mo.observe(panel, { attributes: true, attributeFilter: ["hidden"] });
-}
-
-/**
- *
- * @param {NodeListOf<HTMLAnchorElement>} anchors
- * @param {HTMLElement} panel
- * @param {HTMLElement} dfn
- * @returns
- */
-function createTrapListener(anchors, panel, dfn) {
-  const lastIndex = anchors.length - 1;
-  let currentIndex = 0;
-  return event => {
-    switch (event.key) {
-      // Hitting "Tab" traps us in a nice loop around elements.
-      case "Tab": {
-        event.preventDefault();
-        currentIndex += event.shiftKey ? -1 : +1;
-        if (currentIndex < 0) {
-          currentIndex = lastIndex;
-        } else if (currentIndex > lastIndex) {
-          currentIndex = 0;
+    let panel = null;
+    return event => {
+      const { target, type } = event;
+  
+      if (!(target instanceof HTMLElement)) return;
+  
+      // For keys, we only care about Enter key to activate the panel
+      // otherwise it's activated via a click.
+      if (type === "keydown" && event.key !== "Enter") return;
+  
+      const action = deriveAction(event);
+  
+      switch (action) {
+        case "show": {
+          hidePanel(panel);
+          /** @type {HTMLElement} */
+          const dfn = target.closest("dfn, .index-term");
+          panel = document.getElementById(`dfn-panel-for-${dfn.id}`);
+          const coords = deriveCoordinates(event);
+          displayPanel(dfn, panel, coords);
+          break;
         }
-        anchors.item(currentIndex).focus();
-        break;
+        case "dock": {
+          panel.style.left = null;
+          panel.style.top = null;
+          panel.classList.add("docked");
+          break;
+        }
+        case "hide": {
+          hidePanel(panel);
+          panel = null;
+          break;
+        }
       }
-
-      // Hitting "Enter" on an anchor releases the trap.
-      case "Enter":
-        hidePanel(panel);
-        break;
-
-      // Hitting "Escape" returns focus to dfn.
-      case "Escape":
-        hidePanel(panel);
-        dfn.focus();
-        return;
+    };
+  }
+  
+  /**
+   * @param {MouseEvent|KeyboardEvent} event
+   */
+  function deriveCoordinates(event) {
+    const target = /** @type HTMLElement */ (event.target);
+  
+    // We prevent synthetic AT clicks from putting
+    // the dialog in a weird place. The AT events sometimes
+    // lack coordinates, so they have clientX/Y = 0
+    const rect = target.getBoundingClientRect();
+    if (
+      event instanceof MouseEvent &&
+      event.clientX >= rect.left &&
+      event.clientY >= rect.top
+    ) {
+      // The event probably happened inside the bounding rect...
+      return { x: event.clientX, y: event.clientY };
     }
-  };
-}
-
-/** @param {HTMLElement} panel */
-function hidePanel(panel) {
-  if (!panel) return;
-  panel.hidden = true;
-  panel.classList.remove("docked");
-}
-})()</script><script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script></body></html>
+  
+    // Offset to the middle of the element
+    const x = rect.x + rect.width / 2;
+    // Placed at the bottom of the element
+    const y = rect.y + rect.height;
+    return { x, y };
+  }
+  
+  /**
+   * @param {Event} event
+   */
+  function deriveAction(event) {
+    const target = /** @type {HTMLElement} */ (event.target);
+    const hitALink = !!target.closest("a");
+    if (target.closest("dfn:not([data-cite]), .index-term")) {
+      return hitALink ? "none" : "show";
+    }
+    if (target.closest(".dfn-panel")) {
+      if (hitALink) {
+        return target.classList.contains("self-link") ? "hide" : "dock";
+      }
+      const panel = target.closest(".dfn-panel");
+      return panel.classList.contains("docked") ? "hide" : "none";
+    }
+    if (document.querySelector(".dfn-panel:not([hidden])")) {
+      return "hide";
+    }
+    return "none";
+  }
+  
+  /**
+   * @param {HTMLElement} dfn
+   * @param {HTMLElement} panel
+   * @param {{ x: number, y: number }} clickPosition
+   */
+  function displayPanel(dfn, panel, { x, y }) {
+    panel.hidden = false;
+    // distance (px) between edge of panel and the pointing triangle (caret)
+    const MARGIN = 20;
+  
+    const dfnRects = dfn.getClientRects();
+    // Find the `top` offset when the `dfn` can be spread across multiple lines
+    let closestTop = 0;
+    let minDiff = Infinity;
+    for (const rect of dfnRects) {
+      const { top, bottom } = rect;
+      const diffFromClickY = Math.abs((top + bottom) / 2 - y);
+      if (diffFromClickY < minDiff) {
+        minDiff = diffFromClickY;
+        closestTop = top;
+      }
+    }
+  
+    const top = window.scrollY + closestTop + dfnRects[0].height;
+    const left = x - MARGIN;
+    panel.style.left = `${left}px`;
+    panel.style.top = `${top}px`;
+  
+    // Find if the panel is flowing out of the window
+    const panelRect = panel.getBoundingClientRect();
+    const SCREEN_WIDTH = Math.min(window.innerWidth, window.screen.width);
+    if (panelRect.right > SCREEN_WIDTH) {
+      const newLeft = Math.max(MARGIN, x + MARGIN - panelRect.width);
+      const newCaretOffset = left - newLeft;
+      panel.style.left = `${newLeft}px`;
+      /** @type {HTMLElement} */
+      const caret = panel.querySelector(".caret");
+      caret.style.left = `${newCaretOffset}px`;
+    }
+  
+    // As it's a dialog, we trap focus.
+    // TODO: when <dialog> becomes a implemented, we should really
+    // use that.
+    trapFocus(panel, dfn);
+  }
+  
+  /**
+   * @param {HTMLElement} panel
+   * @param {HTMLElement} dfn
+   * @returns
+   */
+  function trapFocus(panel, dfn) {
+    /** @type NodeListOf<HTMLAnchorElement> elements */
+    const anchors = panel.querySelectorAll("a[href]");
+    // No need to trap focus
+    if (!anchors.length) return;
+  
+    // Move focus to first anchor element
+    const first = anchors.item(0);
+    first.focus();
+  
+    const trapListener = createTrapListener(anchors, panel, dfn);
+    panel.addEventListener("keydown", trapListener);
+  
+    // Hiding the panel releases the trap
+    const mo = new MutationObserver(records => {
+      const [record] = records;
+      const target = /** @type HTMLElement */ (record.target);
+      if (target.hidden) {
+        panel.removeEventListener("keydown", trapListener);
+        mo.disconnect();
+      }
+    });
+    mo.observe(panel, { attributes: true, attributeFilter: ["hidden"] });
+  }
+  
+  /**
+   *
+   * @param {NodeListOf<HTMLAnchorElement>} anchors
+   * @param {HTMLElement} panel
+   * @param {HTMLElement} dfn
+   * @returns
+   */
+  function createTrapListener(anchors, panel, dfn) {
+    const lastIndex = anchors.length - 1;
+    let currentIndex = 0;
+    return event => {
+      switch (event.key) {
+        // Hitting "Tab" traps us in a nice loop around elements.
+        case "Tab": {
+          event.preventDefault();
+          currentIndex += event.shiftKey ? -1 : +1;
+          if (currentIndex < 0) {
+            currentIndex = lastIndex;
+          } else if (currentIndex > lastIndex) {
+            currentIndex = 0;
+          }
+          anchors.item(currentIndex).focus();
+          break;
+        }
+  
+        // Hitting "Enter" on an anchor releases the trap.
+        case "Enter":
+          hidePanel(panel);
+          break;
+  
+        // Hitting "Escape" returns focus to dfn.
+        case "Escape":
+          hidePanel(panel);
+          dfn.focus();
+          return;
+      }
+    };
+  }
+  
+  /** @param {HTMLElement} panel */
+  function hidePanel(panel) {
+    if (!panel) return;
+    panel.hidden = true;
+    panel.classList.remove("docked");
+  }
+  })()</script><script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script></body></html>


### PR DESCRIPTION
Closes #244 

This PR adds a note that explains the adding or removing the monetization attribute has no effect on an already-loaded document.

**🎩 Top-hatting instructions (i.e. human testing that things are not broken)**
1. Pull down this branch
2. Navigate to http://localhost:3000/specification.html#permissions-policy and check that the note is rendering correctly (or you could probably use the deploy preview since we turned that on ¯\\\_(ツ)_/¯)