### PR TITLE
Update permissions policy syntax

### DIFF
--- a/docs/monetization-src.md
+++ b/docs/monetization-src.md
@@ -14,7 +14,7 @@ One or more sources may be allowed for the `monetization-src` policy:
 
 ```html
 Content-Security-Policy: monetization-src <source>;
-Content-Security-Policy: monetization-srce <source>, <source>;
+Content-Security-Policy: monetization-src <source>, <source>;
 ```
 
 ### Sources

--- a/docs/permission-policy-monetization.md
+++ b/docs/permission-policy-monetization.md
@@ -12,7 +12,7 @@ The HTTP [`Permissions-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTT
 ## Syntax
 
 ```html
-Permissions-Policy: monetization <allowlist>
+Permissions-Policy: monetization=<allowlist>;
 ```
 
 `<allowlist>`

--- a/docs/permission-policy.md
+++ b/docs/permission-policy.md
@@ -26,7 +26,7 @@ Controls whether the current document is allowed to use the [Web Monetization AP
 ## Example
 
 ```html
-Permissions-Policy: monetization 'self'
+Permissions-Policy: monetization=(self)
 ```
 
 ## Specifications


### PR DESCRIPTION
Closes #352

Permissions policy pages used the old syntax. Updated to new. Also fixed typo in the CSP monetization-src page.