### PR TITLE
Update default example in link tag generator

### DIFF
--- a/src/pages/link-tag/index.js
+++ b/src/pages/link-tag/index.js
@@ -8,7 +8,7 @@ export default function MetaTag(props) {
   const { config: siteConfig } = props
 
   const [pointerInput, setPointerInput] = useState('')
-  const [pointer, setPointer] = useState('$YourPaymentPointer')
+  const [pointer, setPointer] = useState('https://YourPaymentPointer')
   const [invalidUrl, setInvalidUrl] = useState(false)
 
   const isValidPointer = (pointerInput) => {


### PR DESCRIPTION
Closes #322 

This PR updates the default example on the link tag generator page from 
```
<link rel="monetization" href="$YourPaymentPointer" />
```
to

```
<link rel="monetization" href="https://YourPaymentPointer" />
```