### PR TITLE
Turn on search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -132,12 +132,12 @@ const siteConfig = {
   themes: ['@docusaurus/theme-mermaid'],
 
   themeConfig: {
-    // algolia: {
-    //   apiKey: '9bd462ce100c39e6c9d9b0f37316e3b2',
-    //   indexName: 'webmonetizationorg',
-    //   appId: 'L5XN3RH5F5',
-    //   placeholder: 'Search',
-    // },
+    algolia: {
+      apiKey: '9bd462ce100c39e6c9d9b0f37316e3b2',
+      indexName: 'webmonetizationorg',
+      appId: 'L5XN3RH5F5',
+      placeholder: 'Search',
+    },
     colorMode: {
       defaultMode: 'light',
       disableSwitch: true,
@@ -202,7 +202,7 @@ const siteConfig = {
           label: 'WICG Forum',
         },
         { href: 'https://github.com/WICG/webmonetization', label: 'GitHub' },
-        // { type: 'search', position: 'right' },
+        { type: 'search', position: 'right' },
       ],
     },
     prism: {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -87,7 +87,7 @@ export default function Index(props) {
             <p>
               Web Monetization is being proposed as a W3C standard at{' '}
               <a
-                href='https://discourse.wicg.io/t/proposal-web-monetization-a-new-revenue-model-for-the-web/3785'
+                href='https://web.archive.org/web/20230521023112/https://discourse.wicg.io/t/proposal-web-monetization-a-new-revenue-model-for-the-web/3785'
                 rel='noreferrer noopener'
                 target='_blank'
               >


### PR DESCRIPTION
Closes #364 

This PR turns on search by adding the required configuration options in the docusaurus config file.

**🎩 Top-hatting instructions (i.e. human testing that things are not broken)**
1. Pull down this branch
2. Navigate to http://localhost:3000/ (or you could probably use the deploy preview since we turned that on ¯\\\_(ツ)_/¯) and click on the search bar in the top right corner
3. The overlay should pop-up without errors, and if you start typing, there should be results showing up until you reach a string that we do not have indexed
