### PR TITLE
chore: regularly scheduled dependency updates

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,6 @@ import astroI18next from 'astro-i18next'
 
 import react from '@astrojs/react'
 import overrideIntegration from './src/overrideIntegration.mjs'
-import rehypeMermaid from 'rehype-mermaidjs'
 import remarkMermaid from 'remark-mermaidjs'
 
 // https://astro.build/config
@@ -12,7 +11,6 @@ export default defineConfig({
   site: 'https://webmonetization.org',
   markdown: {
     remarkPlugins: [remarkMermaid],
-    rehypePlugins: [rehypeMermaid],
   },
   integrations: [
     overrideIntegration(),

--- a/package.json
+++ b/package.json
@@ -12,14 +12,13 @@
     "@astrojs/starlight": "^0.7.3",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
-    "astro": "2.10.13",
+    "astro": "2.10.14",
     "astro-i18next": "^1.0.0-beta.21",
     "prism-react-renderer": "^2.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-minimal-pie-chart": "^8.4.0",
-    "rehype-mermaidjs": "^1.0.1",
-    "remark-mermaidjs": "^5.0.1",
+    "remark-mermaidjs": "^5.0.2",
     "sharp": "^0.32.5"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR bumps dependencies and removes unnecessary rehype plugin (it doesn't actually do anything) 