### PR TITLE
feat: add Spanish translation for Intro page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -26,6 +26,10 @@ export default defineConfig({
           label: 'English',
           lang: 'en',
         },
+        es: {
+          label: 'Español',
+          lang: 'es',
+        },
       },
       components: {
         Header: './src/components/docs/Header.astro',

--- a/src/content/docs/es/docs.mdx
+++ b/src/content/docs/es/docs.mdx
@@ -1,0 +1,68 @@
+---
+title: Introducción a la Monetización Web
+---
+
+import { LargeImg, LinkOut, Tooltip } from '@interledger/docs-design-system'
+
+Como usuario de un sitio web, es común encontrar un titular que capte tu atención, sólo para encontrar el artículo bloqueado detrás de un muro de pago. ¿Con qué frecuencia pagas una suscripción para leer un solo artículo? ¿Qué pasaría si pudieras pagar una fracción del precio de la suscripción para acceder al artículo y evitar la suscripción por completo?
+
+Como propietario de un sitio web, anticipas perder algunos visitantes debido al contenido de pago. Incluso si ofreces suscripciones semanales, el precio puede ser mayor de lo que un visitante está dispuesto a pagar. Pero en lugar de suscripciones, ¿qué pasaría si pudieras generar ingresos por contenido, o incluso en función de la cantidad de tiempo que un visitante dedica al contenido?
+
+Éstas son sólo dos formas en que la monetización web puede facilitar los pagos. Con la monetización web, los visitantes del sitio web pueden enviar pagos directamente a los sitios web utilizando una extensión de navegador o cualquier navegador que implemente de forma nativa la especificación de monetización web.
+
+## Infraestructura de pagos actual
+
+Puede llevar un poco de trabajo implementar pagos en un sitio web. Si tu sitio ya acepta pagos, es posible que estés familiarizado con lo que se necesita para aceptar múltiples métodos de pago y monedas. El proceso normalmente se parece a esto:
+
+1. Te registras con uno o más proveedores de pago, según los métodos de pago y las monedas que desees aceptar.
+2. Tú integras sus servicios en tu sitio. Por ejemplo, puedes crear y alojar tu propio formulario de pago que esté conectado al servicio, o utilizar un formulario proporcionado por el proveedor de pagos.
+3. Dependiendo del método de pago que tu visitante desee utilizar, es posible que deba crear una cuenta contigo o con el proveedor de pagos.
+4. Tu visitante completa el formulario de pago. Lo ideal es que permanezcan en tu sitio para completar la transacción, pero es posible que deban acceder al sitio del proveedor.
+
+## Introduciendo la Monetización Web
+
+La Monetización Web (WM por sus siglas en inglés) tiene como objetivo simplificar la experiencia de pago para ti y los visitantes de tu sitio web. Es una tecnología abierta que permite a los sitios web recibir automáticamente pagos de los visitantes, facilitados por el navegador del visitante y su proveedor de WM preferido.
+
+Es un estándar propuesto que permite a los visitantes pagar una cantidad de su elección con poca o ninguna interacción del usuario. Permite que un sitio web indique automáticamente a los navegadores web que puede aceptar pagos y permite a los navegadores web facilitar un pago mediante:
+
+- Obtención de autorización para iniciar el pago.
+- Recopilar detalles y emitir instrucciones para iniciar el proceso de movimiento de dinero.
+- Crear una sesión de pago.
+- Comunicar eventos de pago al sitio para que el sitio pueda responder opcionalmente. Por ejemplo, el sitio podría [eliminar anuncios](/docs/guides/remove-ads) o proporcionar [acceso a contenido exclusivo](/docs/guides/provide-exclusive-content) para los visitantes que pagan.
+
+### Flujo de alto nivel
+
+La siguiente imagen muestra el flujo de monetización web en un nivel alto. Algunos pasos se han combinado o excluido. Se proporciona una explicación más detallada en la página [Flujo de monetización web](/docs/intro/web-monetization-flow).
+
+<LargeImg
+  src='/img/docs/diagram-wm-overview.png'
+  alt='Descripción general de alto nivel del flujo de monetización web'
+/>
+
+1. Bob visita una [página web monetizada](/docs/guides/monetize-page). El elemento de monetización `<link>` es la forma en que el sitio web indica su aceptación de pagos al navegador.
+2. El navegador de Bob, ya sea de forma nativa o mediante una extensión del navegador, analiza el elemento `<link>` para obtener <Tooltip content='Una URL que identifica una cuenta de Open Payments' client:load><a href="./resources/glossary#wallet-address">dirección de billetera</a></Tooltip> de Alice, la propietaria del sitio.
+3. El navegador/extensión de Bob envía solicitudes a la dirección de la billetera de Alice para obtener autorización e instrucciones para enviar un pago.
+4. Con la autorización concedida y las instrucciones de pago recibidas, el navegador/extensión envía solicitudes a la dirección de la billetera de Bob para iniciar el pago.
+5. El flujo de Monetización Web finaliza. El procesamiento de pagos, el cambio de divisas y la liquidación se realizan entre las dos cuentas a través de una vía de pago común.
+
+### Especificación de montos de pago y monedas
+
+La monetización web no permite que un sitio web especifique un monto de pago o moneda. Solo permite que el sitio le indique al navegador que puede aceptar pagos.
+
+Con la ayuda de un <Tooltip content='La entidad que envía un pago' client:load><a href="./resources/glossary#web-monetization-provider">proveedor de WM</a></Tooltip>, tu visitante decide si realiza un pago, cuánto y con qué frecuencia y en qué moneda. Tu <Tooltip content='La entidad que recibe un pago' cliente:load><a href="./resources/glossary#web-monetization-receiver">receptor de WM</a></Tooltip> puede entonces cambiar la moneda de pagos entrantes en función de lo que deseas recibir. Esta flexibilidad te permite a ti y a tus visitantes elegir los métodos de monetización que mejor se adapten a sus necesidades.
+
+### Procesamiento y liquidación de pagos
+
+La función de la monetización web es ayudar a coordinar los pagos. No procesar ni liquidar pagos.
+
+En cada extremo de la monetización web hay una cuenta que admite <LinkOut href="https://openpayments.guide">Open Payments</LinkOut>. El proveedor de WM proporciona a tu visitante una cuenta de envío con fondos. En algunos casos, el visitante podría incluso actuar como su propio proveedor de WM. El receptor WM te proporciona una cuenta receptora.
+
+La monetización web se comunica con las cuentas emisoras y receptoras para obtener las autorizaciones e instrucciones necesarias para que un pago sea enviado y recibido. Luego, el procesamiento y la liquidación de pagos se producen entre las cuentas emisoras y receptoras, fuera del flujo de monetización web.
+
+## Versión de la especificación anterior
+
+En junio de 2023 se publicó una nueva versión de la especificación de Monetización web. Los usuarios de la versión anterior deben tener en cuenta lo siguiente:
+
+- La versión anterior solo utilizaba el Protocolo de configuración de pago simple (SPSP) de Interledger. La nueva versión utiliza <LinkOut href="https://openpayments.guide/">Open Payments</LinkOut>.
+- El elemento `<meta>` está obsoleto en favor del elemento [`<link>`](./references/html-link-rel-monetization/).
+- El elemento `<link>` no admite la forma abreviada de un puntero de pago (por ejemplo, `$wallet.example/alice`). Debes utilizar la URL completa a la que se resuelve el puntero de pago (por ejemplo, `https://wallet.example/alice`). Si necesitas ayuda para convertir un indicador de pago de una abreviatura a su URL equivalente, ingresa su indicador de pago en el campo de entrada en <LinkOut href="https://paymentpointers.org">paymentpointers.org</LinkOut>. En la mayoría de los casos, puedes simplemente reemplazar `$` por `https://`.


### PR DESCRIPTION
Part of #401 

This is a replacement PR for #420 which takes the content from that PR and resolves the incorrect configuration issues.

To test this PR:
1. Go to https://deploy-preview-422--webmonetization-preview.netlify.app/docs/, there should be a language switcher dropdown now
2. Select Español and you should see the Spanish content rendered, with the tooltips also translated (the direct link to the page should be https://deploy-preview-422--webmonetization-preview.netlify.app/es/docs/)