### PR TITLE
fix: change paths in warning message to absolute paths

### DIFF
--- a/src/pages/specification/index.html
+++ b/src/pages/specification/index.html
@@ -350,7 +350,7 @@
           <p>
             This specification is a work in progress within the community on
             the best shape it should take. Please see the <a href=
-            "./docs/">explainer</a> for more info.
+            "https://webmonetization.org/docs/">explainer</a> for more info.
           </p>
           <p>
             The specification reflects the desired end-state of the Web
@@ -363,8 +363,8 @@
           <p>
             For the most accurate reflection of the APIs that have been
             implemented by providers see the <a href=
-            "./docs/references/html-link-rel-monetization/">API
-            documentation</a>.
+            "https://webmonetization.org/docs/references/html-link-rel-monetization/">
+            API documentation</a>.
           </p>
         </div>
       </div>

--- a/src/pages/specification/specification-respec.html
+++ b/src/pages/specification/specification-respec.html
@@ -91,7 +91,7 @@
         <p>
           This specification is a work in progress within the community on the
           best shape it should take. Please see the <a href=
-          "./docs/">explainer</a> for more info.
+          "https://webmonetization.org/docs/">explainer</a> for more info.
         </p>
         <p>
           The specification reflects the desired end-state of the Web
@@ -104,8 +104,8 @@
         <p>
           For the most accurate reflection of the APIs that have been
           implemented by providers see the <a href=
-          "./docs/references/html-link-rel-monetization/">API
-          documentation</a>.
+          "https://webmonetization.org/docs/references/html-link-rel-monetization/">
+          API documentation</a>.
         </p>
       </div>
     </section>


### PR DESCRIPTION
Currently, the links in the warning block use relative paths which end up being broken. This PR updates them to use absolute paths instead.