### PR TITLE
chore: bump dependencies to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/react": "^3.0.10",
-    "@astrojs/starlight": "^0.18.1",
-    "@interledger/docs-design-system": "^0.3.0",
-    "@types/react": "^18.2.55",
-    "@types/react-dom": "^18.2.19",
-    "astro": "4.4.0",
+    "@astrojs/react": "^3.1.0",
+    "@astrojs/starlight": "^0.21.1",
+    "@interledger/docs-design-system": "^0.3.2",
+    "@types/react": "^18.2.67",
+    "@types/react-dom": "^18.2.22",
+    "astro": "4.5.5",
     "astro-i18next": "^1.0.0-beta.21",
     "prettier": "^3.2.5",
     "prism-react-renderer": "^2.3.1",
@@ -21,7 +21,7 @@
     "react-dom": "^18.2.0",
     "react-minimal-pie-chart": "^8.4.0",
     "remark-mermaidjs": "^6.0.0",
-    "respec": "^34.4.0",
+    "respec": "^34.5.0",
     "sharp": "^0.33.2"
   }
 }


### PR DESCRIPTION
This PR bumps dependencies to the latest versions, notably the 0.21.1 version of Starlight which contains the `<Steps>` component that we'd like to utilise.