### PR TITLE
fix: update examples with fetching `incomingPayment`

### DIFF
--- a/src/content/docs/docs/references/attributes/incomingpayment.mdx
+++ b/src/content/docs/docs/references/attributes/incomingpayment.mdx
@@ -37,7 +37,7 @@ async function verifyPayment(event) {
 
   if (response.ok) {
     // The incoming payment was fetched successfully
-    const { receivedAmount } = JSON.parse(response.json())
+    const { receivedAmount } = await response.json()
     const { amount, assetCode, assetScale } = receivedAmount
     console.log(`Received ${assetCode}${amount / Math.pow(10, assetScale)}.`)
   }

--- a/src/pages/specification/includes/verify-payment-example.js
+++ b/src/pages/specification/includes/verify-payment-example.js
@@ -17,7 +17,7 @@ async function verifyPayment(event) {
 
   if (response.ok) {
     // The incoming payment was fetched successfully
-    const { receivedAmount } = JSON.parse(await response.json())
+    const { receivedAmount } = await response.json()
     const { amount, assetCode, assetScale } = receivedAmount
     console.log(`Received ${assetCode}${amount / 10 ** assetScale}.`)
     return receivedAmount


### PR DESCRIPTION
`Response.json()` returns a promise to parsed JSON.