### PR TITLE
feat: add PageTitle and PageSidebar override

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -44,6 +44,8 @@ export default defineConfig({
       },
       components: {
         Header: './src/components/docs/Header.astro',
+        PageSidebar: './src/components/docs/PageSidebar.astro',
+        PageTitle: './src/components/docs/PageTitle.astro',
       },
       social: {
         github: 'https://github.com/WICG/webmonetization',

--- a/package.json
+++ b/package.json
@@ -8,21 +8,21 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/react": "^3.4.0",
-    "@astrojs/starlight": "^0.23.2",
-    "@interledger/docs-design-system": "^0.5.0",
+    "@astrojs/react": "^3.6.0",
+    "@astrojs/starlight": "^0.25.3",
+    "@interledger/docs-design-system": "^0.5.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "astro": "4.9.2",
+    "astro": "4.12.2",
     "astro-i18next": "^1.0.0-beta.21",
-    "prettier": "^3.2.5",
+    "prettier": "^3.3.3",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-minimal-pie-chart": "^8.4.0",
     "remark-mermaidjs": "^6.0.0",
-    "respec": "^35.0.2",
+    "respec": "^35.1.1",
     "sharp": "^0.33.4",
-    "starlight-links-validator": "^0.9.0"
+    "starlight-links-validator": "^0.9.1"
   }
 }

--- a/src/components/docs/PageSidebar.astro
+++ b/src/components/docs/PageSidebar.astro
@@ -1,0 +1,17 @@
+---
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/components/PageSidebar.astro';
+
+const removeOverview = [
+ 'docs/resources/glossary',
+]
+const noOverview = removeOverview.includes(Astro.props.slug);
+const toc = noOverview
+	? {
+			...Astro.props.toc,
+			items: Astro.props.toc?.items.slice(1),
+	  } 
+	: Astro.props.toc;
+---
+
+<Default {...Astro.props} {toc}><slot /></Default>

--- a/src/components/docs/PageTitle.astro
+++ b/src/components/docs/PageTitle.astro
@@ -1,0 +1,24 @@
+---
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/components/PageTitle.astro';
+const { labels, lang, lastUpdated } = Astro.props;
+---
+
+<Default {...Astro.props}><slot /></Default>
+{
+	lastUpdated && (
+		<p class="last-updated">
+			{labels['page.lastUpdated']}{' '}
+			<time datetime={lastUpdated.toISOString()}>
+				{lastUpdated.toLocaleDateString(lang, { dateStyle: 'medium', timeZone: 'UTC' })}
+			</time>
+		</p>
+	)
+}
+
+<style>
+  .last-updated {
+    margin-block-start: var(--space-2xs);
+    font-style: italic;
+  }
+</style>


### PR DESCRIPTION
This PR adds 2 override components:
1. PageTitle: move the updated date from the bottom of the page to the top
2. PageSidebar: remove the "Overview" as the first item of the right sidebar ToC