### PR TITLE
fix: Handle undefined  in PageSidebar component

### DIFF
--- a/src/components/docs/PageSidebar.astro
+++ b/src/components/docs/PageSidebar.astro
@@ -6,7 +6,7 @@ const removeOverview = [
  'docs/resources/glossary',
 ]
 const noOverview = removeOverview.includes(Astro.props.slug);
-const toc = noOverview
+const toc = noOverview && Astro.props.toc !== undefined
 	? {
 			...Astro.props.toc,
 			items: Astro.props.toc?.items.slice(1),


### PR DESCRIPTION
Fix PageSidebar to handle undefined `toc` gracefully so that when it is undefined we do not add an items array since in that instance it would violate the toc's type.