### PR TITLE
chore: basic dependency bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,21 +8,21 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/react": "^3.6.2",
-    "@astrojs/starlight": "^0.26.1",
-    "@interledger/docs-design-system": "^0.5.2",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
-    "astro": "4.14.2",
+    "@astrojs/react": "^4.1.0",
+    "@astrojs/starlight": "^0.29.3",
+    "@interledger/docs-design-system": "^0.5.4",
+    "@types/react": "^19.0.1",
+    "@types/react-dom": "^19.0.2",
+    "astro": "4.16.16",
     "astro-i18next": "^1.0.0-beta.21",
-    "prettier": "^3.3.3",
-    "prism-react-renderer": "^2.3.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-minimal-pie-chart": "^8.4.0",
-    "remark-mermaidjs": "^6.0.0",
-    "respec": "^35.1.1",
+    "prettier": "^3.4.2",
+    "prism-react-renderer": "^2.4.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-minimal-pie-chart": "^9.1.0",
+    "remark-mermaidjs": "^7.0.0",
+    "respec": "^35.2.0",
     "sharp": "^0.33.5",
-    "starlight-links-validator": "^0.10.1"
+    "starlight-links-validator": "^0.13.4"
   }
 }

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,6 +1,5 @@
 ---
 import i18next, { t, changeLanguage } from "i18next";
-import { HeadHrefLangs } from "astro-i18next/components";
 import TopNav from "../components/pages/TopNav.astro";
 import Footer from "../components/pages/Footer.astro";
 import '/node_modules/@interledger/docs-design-system/src/styles/teal-theme.css';
@@ -40,8 +39,6 @@ changeLanguage("en");
   <meta property="twitter:title" content={title} />
   <meta property="twitter:description" content={description} />
   <meta property="twitter:image" content={new URL(image, Astro.url)} />
-
-  <HeadHrefLangs />
 
   <body>
     <TopNav />


### PR DESCRIPTION
There have been a few difficulties with this dependency bump.

Firstly, Starlight, as of now, has a compatibility issue with astro@5. This is being addressed (see [https://github.com/withastro/starlight/pull/2612](https://github.com/withastro/starlight/pull/2612))

Secondly, bumping up the @astrojs/starlight dependency caused compatibility issues with the `HeadHrefLangs` component that is part of the astro-i18next module. Unfortunately, it seems this module is no longer being maintained. As such, I've removed it for now. HeadHrefLangs is a component from astro-i18next that generated <link> tags with hreflang attributes for SEO, specifying alternate language versions of a webpage. This means we need to investigate a new way to build this in and probably use either a different community based plugin for this, or move over to Astro's Built-in i18n Support. This also has limitations which is why it needs more work to figure out the best path.