### PR TITLE
chore: move all tools under /tools

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -235,7 +235,7 @@ export default defineConfig({
   ],
   redirects: {
     "/link-tag": "/tools/link-tag",
-    "/revshare": "/tools/prob-revshare",
+    "/prob-revshare": "/tools/prob-revshare",
     "/docs/references/html-link-rel-monetization": "/docs/references/html"
   },
   server: {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -234,6 +234,8 @@ export default defineConfig({
     astroI18next(),
   ],
   redirects: {
+    "/link-tag": "/tools/link-tag",
+    "/revshare": "/tools/prob-revshare",
     "/docs/references/html-link-rel-monetization": "/docs/references/html"
   },
   server: {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -156,7 +156,7 @@ const pluginsList = data.plugins.filter(function(plugin){
           <p>Explore how Web Monetization works</p>
         </a>
 
-        <a class="gridItem" href="/link-tag" data-umami-event="Landing page - Link tag">
+        <a class="gridItem" href="/tools/link-tag" data-umami-event="Landing page - Link tag">
           <h3 class="heading4">Link Tag Generator</h3>
           <p>Generate a Web Monetization link tag for your site</p>
         </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -161,7 +161,7 @@ const pluginsList = data.plugins.filter(function(plugin){
           <p>Generate a Web Monetization link tag for your site</p>
         </a>
 
-        <a class="gridItem" href="/prob-revshare" data-umami-event="Landing page - Prob rev share">
+        <a class="gridItem" href="/tools/prob-revshare" data-umami-event="Landing page - Prob rev share">
           <h3 class="heading4">Probabilistic RevShare Generator</h3>
           <p>Split Web Monetization revenue between payment pointers</p>
         </a>

--- a/src/pages/install.astro
+++ b/src/pages/install.astro
@@ -86,7 +86,7 @@ const description = t("site.description")
           <div class="cardContent">
             <h2 class="heading3">Get support with a Web Monetization link</h2>
             <h2 class="heading3">
-                <a href="/link-tag/">Generate your link tag</a>
+                <a href="/tools/link-tag/">Generate your link tag</a>
             </h2>
           </div>
         </div>

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -1,6 +1,6 @@
 ---
 import i18next, { t, changeLanguage } from "i18next";
-import Base from "../layouts/Base.astro";
+import Base from "../../layouts/Base.astro";
 
 changeLanguage("en");
 

--- a/src/pages/tools/link-tag.astro
+++ b/src/pages/tools/link-tag.astro
@@ -1,7 +1,7 @@
 ---
 import i18next, { t, changeLanguage } from "i18next";
-import Base from "../layouts/Base.astro";
-import LinkTagGenerator from "../components/pages/LinkTagGenerator";
+import Base from "../../layouts/Base.astro";
+import LinkTagGenerator from "../../components/pages/LinkTagGenerator";
 
 changeLanguage("en");
 

--- a/src/pages/tools/prob-revshare.astro
+++ b/src/pages/tools/prob-revshare.astro
@@ -1,7 +1,7 @@
 ---
 import i18next, { t, changeLanguage } from "i18next";
-import Base from "../layouts/Base.astro";
-import ProbRevshareGenerator from "../components/pages/ProbRevshare";
+import Base from "../../layouts/Base.astro";
+import ProbRevshareGenerator from "../../components/pages/ProbRevshare";
 
 changeLanguage("en");
 


### PR DESCRIPTION
### Changes requested

- Move rev-share and linktag generators under /tools