### PR TITLE
Fix GitHub capitalization typo

### DIFF
--- a/src/components/pages/Footer.astro
+++ b/src/components/pages/Footer.astro
@@ -4,7 +4,7 @@
   <ul>
     <li><a href="https://community.interledger.org/">Community</a></li>
     <li><a href="https://wicg.io/">Web Incubator Community Group</a></li>
-    <li><a href="https://github.com/WICG/webmonetization">Github</a></li>
+    <li><a href="https://github.com/WICG/webmonetization">GitHub</a></li>
   </ul>
   <span>
     Copyright © {new Date().getFullYear()} Interledger Foundation.

--- a/src/components/pages/TopNav.astro
+++ b/src/components/pages/TopNav.astro
@@ -17,7 +17,7 @@
     <ul id="navMenu" class="nav-menu collapsed">
        <li class="nav-link__docs"><a href="/docs" data-umami-event="Landing page - WebMo docs">Documentation</a></li>
        <li class="nav-link__docs"><a href="/specification" data-umami-event="Landing page - WebMo specs">Specification</a></li>
-       <li class="nav-link__github"><a href="https://github.com/WICG/webmonetization/"><img src="/img/icon-github.svg" alt="Link to Github repository"></a></li>
+       <li class="nav-link__github"><a href="https://github.com/WICG/webmonetization/"><img src="/img/icon-github.svg" alt="Link to GitHub repository"></a></li>
     </ul>
  </nav>
 </header>
@@ -189,7 +189,7 @@
     }
   };
 
-  const handleResize = (evt: MediaQueryList | MediaQueryListEvent) => { 
+  const handleResize = (evt: MediaQueryList | MediaQueryListEvent) => {
     if (evt.matches) {
       toggle?.setAttribute('aria-expanded', 'false');
       menu?.classList.remove("collapsed");


### PR DESCRIPTION
This fixes the spelling of "GitHub" to properly reflect the company name.

Additionally it also removes a trailing white space.