### PR TITLE
docs: nav updates

### DIFF
--- a/src/content/docs/developers/link-element-webpage.mdx
+++ b/src/content/docs/developers/link-element-webpage.mdx
@@ -1,5 +1,5 @@
 ---
-title: Monetization <link> element
+title: Webpage (HTML)
 ---
 import { Badge } from '@astrojs/starlight/components'
 import Overview from "/src/partials/link-element-overview.mdx";

--- a/src/content/docs/developers/tools.mdx
+++ b/src/content/docs/developers/tools.mdx
@@ -3,6 +3,9 @@ title: Publisher tools
 banner:
     content: |
         More tools coming soon!
+next:
+  link: /wallets
+  label: Compatible digital wallets
 ---
 
 import { LinkButton } from '@astrojs/starlight/components';

--- a/src/partials/link-element-overview.mdx
+++ b/src/partials/link-element-overview.mdx
@@ -1,1 +1,1 @@
-From a creator/developer perspective, the monetization `<link>` element is one of the two key pieces to web monetizing a page. The second piece is a wallet address/payment pointer.
+From a creator/developer perspective, the monetization `<link>` element is one of the two key pieces to web monetizing an HTML page. The second piece is a wallet address/payment pointer.


### PR DESCRIPTION
specified "HTML" page in link element overview partial, changed page title of monetization link element page version that is in the wallet linking section. changed the "next" link at the bottom of the publishers tools page from the spec to the compatible wallets page, because the spec opens in a new window. this change at least keeps the reader in the docs.