### PR TITLE
chore: bump dependencies and update PageSidebar implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/react": "^4.2.3",
-    "@astrojs/starlight": "^0.33.0",
+    "@astrojs/react": "^4.2.4",
+    "@astrojs/starlight": "^0.34.0",
     "@interledger/docs-design-system": "^0.6.2",
-    "@types/react": "^19.1.0",
-    "@types/react-dom": "^19.1.1",
-    "astro": "5.6.1",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "astro": "5.7.2",
     "prettier": "^3.5.3",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.1.0",
@@ -22,6 +22,6 @@
     "remark-mermaidjs": "^7.0.0",
     "respec": "^35.3.0",
     "sharp": "^0.34.1",
-    "starlight-links-validator": "^0.15.0"
+    "starlight-links-validator": "^0.16.0"
   }
 }

--- a/src/components/docs/PageSidebar.astro
+++ b/src/components/docs/PageSidebar.astro
@@ -1,17 +1,17 @@
 ---
-import type { Props } from '@astrojs/starlight/props';
 import Default from '@astrojs/starlight/components/PageSidebar.astro';
 
 const removeOverview = [
-	'docs/resources/glossary',
+ 'resources/glossary'
 ]
-const noOverview = removeOverview.includes(Astro.props.slug);
-const toc = noOverview && Astro.props.toc !== undefined
-	? {
-			...Astro.props.toc,
-			items: Astro.props.toc?.items.slice(1),
-	  } 
-	: Astro.props.toc;
+const { id, toc } = Astro.locals.starlightRoute;
+const noOverview = removeOverview.includes(id);
+console.log(id)
+if (noOverview && toc) {
+	Astro.locals.starlightRoute.toc = {
+		...toc,
+		items: toc.items.slice(1),
+	};
+}
 ---
-
-<Default {...Astro.props} {toc}><slot /></Default>
+<Default />


### PR DESCRIPTION
This PR bumps dependencies to the latest versions and also updates the PageSidebar implementation to replace deprecated features and update the glossary page URL.