### PR TITLE
fix(TopNav): fix broken /en home page link

### DIFF
--- a/src/components/pages/TopNav.astro
+++ b/src/components/pages/TopNav.astro
@@ -3,10 +3,11 @@ import { getLangFromUrl, useTranslations } from '../../i18n/utils';
 
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
+const homePageUrl = lang === 'en' ? '/' : `/${lang}/`;
 ---
 <header>
   <nav class="site-nav">
-    <a href={`/${lang}/`} class="site-title">
+    <a href={homePageUrl} class="site-title">
       <img src="/img/wm-logo.svg" alt="Web Monetization logo">
       <span>Web Monetization</span>
     </a>


### PR DESCRIPTION
Closes https://github.com/interledger/web-monetization-tools/issues/95 (originally reported there).

`/en` is 404
_(well I temporarily added a 301 redirect in Cloudflare)_