### PR TITLE
docs: consistent use of continuous payments

### DIFF
--- a/src/content/docs/developers/about-receiving.mdx
+++ b/src/content/docs/developers/about-receiving.mdx
@@ -38,7 +38,14 @@ Your visitors' Web Monetization extension acts like a messaging service. When th
 
 ### Micropayments
 
-If you're already familiar with Web Monetization, you may have heard about how it supports micropayments.
+If you're already familiar with Web Monetization, you may have heard about how it supports micropayments. Continuous payments typically involve micropayments, which are small amounts sent based on the time spent on a web monetized page.
+
+:::tip[Types of payments]
+Web Monetization supports two types of payments:
+
+- Continuous payments are typically ongoing micropayments sent automatically as users engage with your web monetized content over time.
+- One-time payments are single payments made by users to express their gratitude or support.
+:::
 
 In general, a micropayment is a very small payment. Each wallet provider is responsible for a few things:
 

--- a/src/content/docs/docs.mdx
+++ b/src/content/docs/docs.mdx
@@ -10,7 +10,7 @@ Web Monetization is a technology that enables websites to receive payments from 
 
 Website owners, content owners, and publishers can use Web Monetization to replace or complement existing revenue models. 
 
-Site visitors can make a one-time contribution or send small continuous payments as they spend time on web monetized content. The amount and frequency of payments is chosen by the visitor, not the website. 
+Site visitors can make a one-time contribution or send continuous payments as they spend time on web monetized content. The amount and frequency of payments is chosen by the visitor, not the website. 
 
   <CardGrid>
     <LinkCard title="For visitors to web monetized content" href="/supporters/overview" description="As a content consumer, you pay as much or as little as you want, as often as you want, as you spend time on web monetized sites." />

--- a/src/content/docs/guides/send-test-payments.mdx
+++ b/src/content/docs/guides/send-test-payments.mdx
@@ -47,7 +47,7 @@ Check the status of the extension.
 
 Each payment appears within the *Monetization events* section on the test site.<br /><img src='/img/docs/testwallet/testwallet-sid-continuous-events.png' alt='Monetization events section showing two payments of MXN 0.21' style='max-width:250px' class='img-outline'/>
 
-If your extension is using <abbr title="US dollars">USD</abbr> with the default rate of $0.60 an hour, a new event appears on the site about every two minutes as long as the window is active. Continuous (streaming) Web Monetization payments stop when the window is inactive. Keep the window active until a few payment events appear. Then, sign in to your <LinkOut href="https://wallet.interledger-test.dev/">wallet account</LinkOut> and select **Transactions** to see the payments you've sent.
+If your extension is using <abbr title="US dollars">USD</abbr> with the default rate of $0.60 an hour, a new event appears on the site about every two minutes as long as the window is active. Continuous payments stop when the window is inactive. Keep the window active until a few payment events appear. Then, sign in to your <LinkOut href="https://wallet.interledger-test.dev/">wallet account</LinkOut> and select **Transactions** to see the payments you've sent.
 
 ## Send a one-time payment
 

--- a/src/content/docs/supporters/about-sending.mdx
+++ b/src/content/docs/supporters/about-sending.mdx
@@ -42,7 +42,7 @@ Your Web Monetization extension acts like a messaging service. It requests infor
 
 ### Micropayments
 
-If you're already familiar with Web Monetization, you may have heard about how it supports micropayments.
+If you're already familiar with Web Monetization, you may have heard about how it supports micropayments. Continuous payments typically involve micropayments, which are small amounts sent based on the time spent on a web monetized page.
 
 In general, a micropayment is a very small payment. Each wallet provider is responsible for:
 

--- a/src/content/docs/supporters/overview.mdx
+++ b/src/content/docs/supporters/overview.mdx
@@ -8,7 +8,7 @@ import { LinkOut } from '@interledger/docs-design-system'
 
 Web Monetization is an immediate and secure way for you to support websites, content owners, and publishers. 
 
-With Web Monetization, you can express your gratitude by making a one-time contribution or by sending small continuous payments as you spend time on their content. Visit the [Get started](/supporters/get-started) page for instructions.
+With Web Monetization, you can express your gratitude by making a one-time contribution or by sending continuous payments as you spend time on their content. Visit the [Get started](/supporters/get-started) page for instructions.
 
 ## Benefits
 


### PR DESCRIPTION
After reviewing the Web Monetization docs as a whole, I’ve made a few changes and included them in this pull request. I’d like to explain my thought process and rationale behind these changes.

To me, there were a few permutations of word choices which are evident in the GitHub issue, the Web Monetization specification, and the Web Monetization documentation. Here’s the words in question:

- Streaming vs. continuous
- Payment vs. micropayment

Do we call it streaming payments, continuous micropayments, or something in between?

I recommend continuous payments, and here’s why:

- It’s aligned with the user interface. The toggle in the browser extension is “continuous payment” and choosing to keep the same terminology will help alleviate any confusion.
- “Streaming” itself is a difficult word, especially in the technology realm. It can mean anything from consuming media (Netflix, Hulu, etc.) to streaming data (Kafka, Confluent, etc.) to the STREAM Interledger protocol.  Trying to distinguish this word for our web monetization purposes might introduce some unnecessary confusion.
- “Continuous micropayments” feels a little redundant since most, if not all, continuous payments fall into that category. It’s still important to define and talk about micropayments, but only in the proper contexts ([sending payments](https://webmonetization.org/supporters/about-sending/), [receiving payments](https://webmonetization.org/developers/about-receiving/))