### PR TITLE
feat: added a component used for text where emphasis is needed

### DIFF
--- a/src/components/docs/EmphasisText.astro
+++ b/src/components/docs/EmphasisText.astro
@@ -1,0 +1,12 @@
+---
+const { text } = Astro.props;
+---
+<p>
+    <strong class="emphasisText">{text}</strong>
+</p>
+
+<style>
+    .emphasisText {
+        font-size: var(--sl-text-h3);
+    }
+</style>


### PR DESCRIPTION
For the content owner and content supporter overview pages it would be nice to have text that brings emphasis and clearly separates points but this text is not strictly a heading so I made a local component that can style the text as if it were a heading but without the stylish underline.

Usage:
```
import EmphasisText from '/src/components/docs/EmphasisText.astro'

<EmphasisText text='The network of Web Monetization-enabled wallet providers is nascent, but growing.' />
```