### PR TITLE
fix(/play): add link tags from URL to the page in one-go

### DIFF
--- a/src/pages/play.astro
+++ b/src/pages/play.astro
@@ -225,7 +225,7 @@ const description = t("site.description");
     }, 500)
   }
 
-  async function createLinkTag(href: string) {
+  function createLinkTag(href: string) {
     const link = document.createElement('link')
 
     link.rel = 'monetization'
@@ -405,19 +405,18 @@ const description = t("site.description");
     }
 
     await createLinkEventLog(walletAddressUrl)
-    await createLinkTag(walletAddressUrl)
+    createLinkTag(walletAddressUrl)
 
     form.reset()
   })
 
   async function addTagsFromURL() {
     const walletAddressUrls = new URLSearchParams(location.search).getAll('wa')
-    for (const url of walletAddressUrls) {
-      if (isWalletAddressUrl(url) && !addressAlreadyAdded(url)) {
-        await createLinkEventLog(url)
-        await createLinkTag(url)
-      }
+    const urlsToAdd = new Set(walletAddressUrls.filter(isWalletAddressUrl))
+    for (const url of urlsToAdd) {
+      await createLinkEventLog(url)
     }
+    urlsToAdd.forEach(createLinkTag)
   }
 
   function isWalletAddressUrl(s: string): boolean {


### PR DESCRIPTION
Opening https://webmonetization.org/play/?wa=https://ilp.interledger-test.dev/sid-zar-1&wa=https://ilp.interledger-test.dev/sid-mxn-1 right now adds the link tags in two `MutationObserver` mutation callbacks, so the WM extension receives two `START_MONETIZATION` events. As we use this playground in our E2E tests, we have trouble detecting which link tag gets more payments allotted depending on the order they get added to page - making tests unreliable.

With this PR, we add link tags from URL together, having a single `START_MONETIZATION` event, making our tests more reliable.