### PR TITLE
fix: ensure analytics script markup is consistent & valid

### DIFF
--- a/src/components/AnalyticsScript.astro
+++ b/src/components/AnalyticsScript.astro
@@ -1,0 +1,6 @@
+<!-- https://stackoverflow.com/questions/78428607/how-to-use-script-tag-with-custom-attributes-in-the-layout-astro-file -->
+<script
+  defer
+  src='https://ilf-site-analytics.netlify.app/script.js'
+  data-website-id='3b8cb97a-2a94-43c2-85e7-277c92c9cf48'
+  data-domains='webmonetization.org'></script>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,6 +3,7 @@ import { getLangFromUrl, useTranslations } from '../i18n/utils';
 import TopNav from "../components/pages/TopNav.astro";
 import Footer from "../components/pages/Footer.astro";
 import '/node_modules/@interledger/docs-design-system/src/styles/teal-theme.css';
+import AnalyticsScript from '../components/AnalyticsScript.astro';
 import '../styles/webm.css';
 
 interface Props {
@@ -29,7 +30,7 @@ const { title = t("site.title"), description = t("site.description"), image = '/
   <meta name="title" content={title} />
   <meta name="description" content={description} />
 
-  <script defer src="https://ilf-site-analytics.netlify.app/script.js" data-website-id="3b8cb97a-2a94-43c2-85e7-277c92c9cf48" data-domains: "webmonetization.org"></script>
+  <AnalyticsScript />
 
   <meta property="og:type" content="website" />
   <meta property="og:url" content={Astro.url} />


### PR DESCRIPTION
Fixes #575 

- Ensure `data-domains` attribute is added correctly.
- Move the script into its own component, otherwise Astro will process the script and remove all the custom attributes.
- Now the script is same as we'd have on Starlight docs.