### PR TITLE
chore: improve icon visibility in dark mode

### DIFF
--- a/src/components/ExtensionLinks.astro
+++ b/src/components/ExtensionLinks.astro
@@ -147,12 +147,12 @@ const toURL = (url: string) => {
     transition: box-shadow 0.2s ease-in-out;
   }
 
-  html[data-theme="dark"] a {
+  html[data-theme='dark'] a {
     background-color: var(--sl-color-white);
-    --shadow-color:rgba(128, 123, 123, 0.7);
+    --shadow-color: rgba(128, 123, 123, 0.7);
   }
 
-  .docs img {    img {
+  .docs img {
     width: 3rem;
     height: 3rem;
   }

--- a/src/components/docs/Libraries.astro
+++ b/src/components/docs/Libraries.astro
@@ -34,22 +34,11 @@ const findStartWith = (array: any[], arg: string) => {
           {findStartWith(plugin.version, '1.') ? '✅' : '❌'}
         </td>
         <td class="cellCenter">
-<<<<<<< HEAD
           <a href={plugin.cta.href}>
-            <img
-              alt={`Link to ${plugin.name}'s GitHub repo`}
-              src={githubIcon.src}
-              class="icon--github"
-              width={githubIcon.width}
-              height={githubIcon.height}
-            />
-=======
-          <a href={plugin.link}>
             <svg role="img" class="icon--github" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <title>{`Link to ${plugin.name}'s GitHub repo`}</title>
               <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
             </svg>
->>>>>>> f8710c2 (chore: improve icon visibility in dark mode)
           </a>
         </td>
       </tr>


### PR DESCRIPTION
Issue described here: Linear issue [DOCS-21](https://linear.app/interledger/issue/DOCS-21/dark-mode-bugs)

- replaced embedded SVGs with inline SVGs
- public/img/icon-github.svg is still in use, so it has not been removed