### PR TITLE
docs: format image guidelines in README as a bulleted list

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Static image assets should be placed in the `public/img/docs` directory. When re
 ![A lovely description of your beautiful image](/img/your-beautiful-image.png)
 ```
 
-⭐ Make your image accessible by including helpful alt text that describes the image.
-⭐ Ensure your file name is descriptive. A file name of `img01.png` isn't helpful.
+⭐ Make your image accessible by including helpful alt text that describes the image. <br>
+⭐ Ensure your file name is descriptive. A file name of `img01.png` isn't helpful. <br>
 ⭐ Use hyphens instead of underscores in file names to keep our naming conventions consistent.
 
 #### Components


### PR DESCRIPTION
## Description
Fixes #604 

This PR improves the readability of the image contribution guidelines in the `README.md` file by converting a single long line into a properly formatted markdown list.

## Changes Made
- Replaced the single-line string of guidelines with a multi-line bulleted list.
- The content and meaning of the guidelines remain unchanged.

## Before

<img width="1092" height="122" alt="image" src="https://github.com/user-attachments/assets/b116fb10-2a19-4159-bf80-0366cc874caa" />


## After

<img width="952" height="120" alt="image" src="https://github.com/user-attachments/assets/dac1acc9-2093-4ae3-af63-ebd50b77a8d0" />


## Testing
N/A - This is a documentation-only change. Verified the markdown renders correctly in a preview.