### PR TITLE
fix(/play): go to /developers with "Go back" link, not /tools

### DIFF
--- a/src/components/pages/ToolsHeader.astro
+++ b/src/components/pages/ToolsHeader.astro
@@ -9,7 +9,7 @@ interface Props {
 }
 const { headingText, pageTitle, backButtonText } = Astro.props
 const lang = getLangFromUrl(Astro.url)
-const toolsUrl = lang === 'en' ? '/tools' : `/${lang}/tools`
+const toolsUrl = lang === 'en' ? '/developers' : `/${lang}/developers`
 ---
 
 <div class='header'>


### PR DESCRIPTION
## Description
This PR fixes a broken link where the "Go back" button was incorrectly navigating users to `/tools` instead of the intended `/developers` page.

## Changes Made
- Updated the href attribute for the "Go back" button from `/tools` to `/developers`.

## Issue Fixed
Fixes #606 

## After Fixing

https://github.com/user-attachments/assets/67dce380-d840-4670-b1c6-a9f8b9f98eb2


## Notes
This was a straightforward link correction with no side effects on other functionality.