### PR TITLE
fix(/welcome): prevent heading overflow on mobile

### DIFF
--- a/src/pages/welcome.astro
+++ b/src/pages/welcome.astro
@@ -47,7 +47,7 @@ const description = t("site.description");
     font: var(--font-h2);
     line-height: 1.2;
     color: var(--wm-accent);
-    width: 25ch;
+    max-width: 25ch;
   }
 
   .heroContent p {


### PR DESCRIPTION
Try visiting https://webmonetization.org/welcome/?result=grant_success&intent=connect on a smaller screen. The heading having a fixed width meant it overflowed on mobile.

Eventually, we'll move this welcome screen to be within extension (https://github.com/interledger/web-monetization-extension/issues/1238), there we'll address more responsiveness issues, but for now, this will do for Firefox Android support priority (https://github.com/interledger/web-monetization-extension/issues/720).