### PR TITLE
chore: fix broken wordpress links

### DIFF
--- a/src/data/publishers.ts
+++ b/src/data/publishers.ts
@@ -76,12 +76,12 @@ export const wordPressPluginContent: ContentSection = {
   title: 'Add Web Monetization to WordPress. Fast, Free, Private.',
   primaryCta: {
     text: 'Get the WordPress plugin',
-    href: '',
+    href: 'https://wordpress.org/plugins/interledger-web-monetization-integration/',
     event: 'Publishers page - WP plugin'
   },
   secondaryCta: {
     text: 'See the documentation',
-    href: '/publishers/overview/',
+    href: '/publishers/wordpress/',
     event: 'Publishers page - Developer docs'
   }
 }


### PR DESCRIPTION
The WordPress links on the Publishers page were broken so we have them fixed here.