### PR TITLE
docs: fix code blocks

### DIFF
--- a/src/content/docs/supporters/get-started.mdx
+++ b/src/content/docs/supporters/get-started.mdx
@@ -48,25 +48,13 @@ After you install the extension, a page appears to guide you through the configu
      style="max-width:300px"
      class="img-outline"
    />
-2. Find and copy your wallet address (Interledger) or payment pointer (GateHub). You'll need it for Step 4.
+2. Find and copy your wallet address (Interledger) or payment pointer (GateHub). You'll need it for Step 4. Wallet addresses follow the format of `https://wallet.example.com/alice`. Payment pointers follow the format of `$wallet.example.com/alice`.
    <img
      src="/img/docs/extension/onboarding-2.png"
      alt="Interledger Wallet dashboard displaying a wallet address"
      style="max-width:400px"
      class="img-outline"
    />
-   <Tabs>
-     <TabItem label="Example wallet address">
-       ```text 
-       https://wallet.example.com/alice
-       ```
-     </TabItem>
-     <TabItem label="Example payment pointer">
-       ```text 
-       $wallet.example.com/alice 
-       ```
-     </TabItem>
-   </Tabs>
 3. Pin the extension to your toolbar (optional).
    <img
      src="/img/docs/extension/onboarding-3.png"


### PR DESCRIPTION
The language of the code blocks (`text`) in step 2 was user-facing because it was all on a single line.