### PR TITLE
fix: updated Starlight Search inclusion to respect props API change

### DIFF
--- a/src/components/docs/Header.astro
+++ b/src/components/docs/Header.astro
@@ -1,5 +1,4 @@
 ---
-import type { Props } from '@astrojs/starlight/props'
 import Search from '@astrojs/starlight/components/Search.astro'
 import ThemeSelect from '@astrojs/starlight/components/ThemeSelect.astro'
 import SocialIcons from '@astrojs/starlight/components/SocialIcons.astro'
@@ -18,7 +17,7 @@ import wmLogo from '@assets/wm-logo.svg'
     <span>Web Monetization</span>
   </a>
   <div class="secondary-wrap">
-    <Search {...Astro.props} />
+    <Search />
     <SocialIcons {...Astro.props} />
     <div class="sl-hidden md:sl-flex selects">
       <ThemeSelect {...Astro.props} />


### PR DESCRIPTION
The search functionality was broken on the docs.

<img width="658" height="264" alt="image" src="https://github.com/user-attachments/assets/e2a4ade6-f51c-4d7c-9fd5-7b724306ecf6" />

```
ui-core.5vfW5kUq.js:1 GET https://webmonetization.org/pagefind/pagefind.js net::ERR_ABORTED 404 (Not Found) (anonymous) @ ui-core.5vfW5kUq.js:1 (anonymous) @ preload-helper.BlTxHScW.js:1 Promise.then y @ preload-helper.BlTxHScW.js:1 Ne @ ui-core.5vfW5kUq.js:1 l @ Search.astro_astro_t…_lang.ZeYNpLV4.js:2
```

There was a breaking change to how Astro Props works and this must have fallen through in our dependency updates. You can see the release notes [here](https://github.com/withastro/starlight/releases/tag/%40astrojs%2Fstarlight%400.32.0).

You'll see the search is working now in the deploy preview.
