### PR TITLE
docs(CONTRIBUTING): improve spec contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,14 +21,14 @@ If you are making a pull request on behalf of someone else but you had no part i
 
 ## Specification Development
 
-If you are interested in making changes to the specification, set up this repository on your local machine first. You can follow the [instructions on the README](./README.md#get-set-up).
+If you are interested in making changes to the specification, set up this repository on your local machine first. You can follow the [instructions on the README](./README.md#get-set-up), but you don't necessarily need to install dependencies or set up an environment if you want to work on the specification only (and not rest of the website).
 
-The source file for the specification document is at [src/pages/specification/specification-respec.html](https://github.com/WICG/webmonetization/tree/main/src/pages/specification/specification-respec.html). This is the raw ReSpec version that editors should make changes and updates to. Documentation for ReSpec can be accessed on the [ReSpec Wiki](https://github.com/w3c/respec/wiki/).
+The source file for the specification document is at [specification/index.html](./specification/index.html). This is the raw ReSpec version that editors should make changes to. Documentation for ReSpec can be accessed on the [respec.org](https://respec.org/docs/).
 
-Preview changes with `npx http-server ./src/pages/specification/` and opening http://localhost:8080/specification-respec.html . (The Astro dev server interferes with example inclusion.)
+Preview changes with `npx serve ./specification/` (or [any other static HTTP file server](https://gist.github.com/willurd/5720255)) and opening http://localhost:3000/index.html .
 
-Export a static HTML version of the specification when your changes are done with `src/pages/specification/respec.sh`. (You may need to install `tidy` with `brew install tidy-html5`.)
+Similar to the main specification, there are also [WM flows](./specification/flows/) and [browser extension API](./specification/extensions-api/) implementation specifications.
 
-In general, Community Group Draft Reports do not follow the same strict conventions as more mature specifications. We only archive major versions of the specification. For example, a copy of the [2021-03-17 draft report](https://github.com/WICG/webmonetization/tree/main/src/pages/specification/versions/CG-DRAFT-web-monetization-20210317.html) currently lives in [src/pages/specification/versions/](https://github.com/WICG/webmonetization/tree/main/src/pages/specification/versions).
+In general, Community Group Draft Reports do not follow the same strict conventions as more mature specifications. We only archive major versions of the specification. For example, a copy of the [2021-03-17 draft report](./specification/versions/CG-DRAFT-web-monetization-20210317.html) currently lives in [specification/versions/](./specification/versions).
 
-Prettier is disabled on `src/pages/specification` as it conflicts with the code format style used by W3C specifications. There is [no way](https://github.com/prettier/prettier/issues/5246) to configure Prettier to follow the [W3C recommendation](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements) of not using trailing slashes on void elements.
+Prettier is disabled on `specification/*` as it conflicts with the code format style used by W3C specifications. There is [no way](https://github.com/prettier/prettier/issues/5246) to configure Prettier to follow the [W3C recommendation](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements) of not using trailing slashes on void elements.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ If you are interested in making changes to the specification, set up this reposi
 
 The source file for the specification document is at [specification/index.html](./specification/index.html). This is the raw ReSpec version that editors should make changes to. Documentation for ReSpec can be accessed on the [respec.org](https://respec.org/docs/).
 
-Preview changes with `npx serve ./specification/` (or [any other static HTTP file server](https://gist.github.com/willurd/5720255)) and opening http://localhost:3000/index.html .
+Preview changes with `npx serve ./specification/` (or [any other static HTTP file server](https://gist.github.com/willurd/5720255)) and opening http://localhost:3000/index.html.
 
-Similar to the main specification, there are also [WM flows](./specification/flows/) and [browser extension API](./specification/extensions-api/) implementation specifications.
+Similar to the main specification, there are also [Web Monetization flows](./specification/flows/) and the [browser extension API](./specification/extensions-api/) implementation specifications.
 
 In general, Community Group Draft Reports do not follow the same strict conventions as more mature specifications. We only archive major versions of the specification. For example, a copy of the [2021-03-17 draft report](./specification/versions/CG-DRAFT-web-monetization-20210317.html) currently lives in [specification/versions/](./specification/versions).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The website is the home of the proposed Web Monetization standard currently incu
 
 You can read the [docs](https://webmonetization.org/docs/), or read the proposed [specification](https://webmonetization.org/specification).
 
-# Contribute
+## Contribute
 
 The Web Monetization website is built with [Starlight](https://starlight.astro.build/), a documentation framework based on [Astro](https://astro.build/).
 
@@ -14,6 +14,10 @@ The Web Monetization website is built with [Starlight](https://starlight.astro.b
 - [Content](#content)
 - [Localization/Internationalization](#localizationinternationalization)
 - [Reviews and Approvals](#reviews-and-approvals)
+
+## Specification Development
+
+Please refer to the [CONTRIBUTING.md](./CONTRIBUTING.md#specification-development).
 
 ## Get Set Up
 
@@ -47,10 +51,6 @@ All commands are run from the root of the project, from a terminal:
 | `bun run format`          | Format code and fix linting issues automatically           |
 
 You can substitute the bun commands with your chosen package manager's commands.
-
-## Specification Development
-
-Please refer to the [CONTRIBUTING.md](./CONTRIBUTING.md#specification-development).
 
 ## Content
 


### PR DESCRIPTION
Specification editors don't need to setup Bun/Node.js etc. Improve instructions so spec editors can get started more easily.