### PR TITLE
fix: added missing data umami event attributes to Web Monetization links

### DIFF
--- a/src/components/ExtensionLinks.astro
+++ b/src/components/ExtensionLinks.astro
@@ -41,7 +41,7 @@ const toURL = (url: string) => {
 <ul class={variant}>
   <li>
     <div class="container">
-      <a href={toURL(URLS.chrome)} title={t('media.title.extension.chrome')}>
+      <a href={toURL(URLS.chrome)} title={t('media.title.extension.chrome')} data-umami-event="Extension - Chrome">
         <img
           src={chromeWebstore.src}
           alt={t('media.title.extension.chrome')}
@@ -53,7 +53,7 @@ const toURL = (url: string) => {
   </li>
   <li>
     <div class="container">
-      <a href={toURL(URLS.firefox)} title={t('media.title.extension.firefox')}>
+      <a href={toURL(URLS.firefox)} title={t('media.title.extension.firefox')} data-umami-event="Extension - Firefox">
         <img
           src={fxBrowserIcon.src}
           alt={t('media.title.extension.firefox')}
@@ -65,7 +65,7 @@ const toURL = (url: string) => {
   </li>
   <li>
     <div class="container">
-      <a href={toURL(URLS.safari)} title={t('media.title.extension.safari')}>
+      <a href={toURL(URLS.safari)} title={t('media.title.extension.safari')} data-umami-event="Extension - Safari">
         <img
           src={safariIcon.src}
           alt={t('media.title.extension.safari')}
@@ -77,7 +77,7 @@ const toURL = (url: string) => {
   </li>
   <li>
     <div class="container">
-      <a href={toURL(URLS.edge)} title={t('media.title.extension.edge')}>
+      <a href={toURL(URLS.edge)} title={t('media.title.extension.edge')} data-umami-event="Extension - Edge">
         <img
           src={microsoftEdge.src}
           alt={t('media.title.extension.edge')}
@@ -94,6 +94,7 @@ const toURL = (url: string) => {
           <a
             href={toURL(URLS.github)}
             title={t('media.title.extension.github')}
+            data-umami-event="Extension - GitHub"
           >
             <img
               alt={t('media.title.extension.github')}

--- a/src/components/ExtensionLinks.astro
+++ b/src/components/ExtensionLinks.astro
@@ -41,7 +41,11 @@ const toURL = (url: string) => {
 <ul class={variant}>
   <li>
     <div class="container">
-      <a href={toURL(URLS.chrome)} title={t('media.title.extension.chrome')} data-umami-event="Extension - Chrome">
+      <a
+        href={toURL(URLS.chrome)}
+        title={t('media.title.extension.chrome')}
+        data-umami-event="Extension - Chrome"
+      >
         <img
           src={chromeWebstore.src}
           alt={t('media.title.extension.chrome')}
@@ -53,7 +57,11 @@ const toURL = (url: string) => {
   </li>
   <li>
     <div class="container">
-      <a href={toURL(URLS.firefox)} title={t('media.title.extension.firefox')} data-umami-event="Extension - Firefox">
+      <a
+        href={toURL(URLS.firefox)}
+        title={t('media.title.extension.firefox')}
+        data-umami-event="Extension - Firefox"
+      >
         <img
           src={fxBrowserIcon.src}
           alt={t('media.title.extension.firefox')}
@@ -65,7 +73,11 @@ const toURL = (url: string) => {
   </li>
   <li>
     <div class="container">
-      <a href={toURL(URLS.safari)} title={t('media.title.extension.safari')} data-umami-event="Extension - Safari">
+      <a
+        href={toURL(URLS.safari)}
+        title={t('media.title.extension.safari')}
+        data-umami-event="Extension - Safari"
+      >
         <img
           src={safariIcon.src}
           alt={t('media.title.extension.safari')}
@@ -77,7 +89,11 @@ const toURL = (url: string) => {
   </li>
   <li>
     <div class="container">
-      <a href={toURL(URLS.edge)} title={t('media.title.extension.edge')} data-umami-event="Extension - Edge">
+      <a
+        href={toURL(URLS.edge)}
+        title={t('media.title.extension.edge')}
+        data-umami-event="Extension - Edge"
+      >
         <img
           src={microsoftEdge.src}
           alt={t('media.title.extension.edge')}

--- a/src/components/docs/Header.astro
+++ b/src/components/docs/Header.astro
@@ -7,7 +7,7 @@ import wmLogo from '@assets/wm-logo.svg'
 ---
 
 <div class="header sl-flex">
-  <a href="/" class="site-title">
+  <a href="/" class="site-title" data-umami-event="Docs - Home">
     <img
       src={wmLogo.src}
       alt="Web Monetization logo"

--- a/src/components/docs/Libraries.astro
+++ b/src/components/docs/Libraries.astro
@@ -41,7 +41,7 @@ const findStartWith = (array: string[], arg: string) => {
               {findStartWith(plugin.version, '1.') ? '✅' : '❌'}
             </td>
             <td class="cellCenter">
-              <a href={plugin.cta.href}>
+              <a href={plugin.cta.href} data-umami-event={`Docs - ${plugin.name} GitHub`}>
                 <svg
                   role="img"
                   class="icon--github"

--- a/src/components/docs/Libraries.astro
+++ b/src/components/docs/Libraries.astro
@@ -41,7 +41,10 @@ const findStartWith = (array: string[], arg: string) => {
               {findStartWith(plugin.version, '1.') ? '✅' : '❌'}
             </td>
             <td class="cellCenter">
-              <a href={plugin.cta.href} data-umami-event={`Docs - ${plugin.name} GitHub`}>
+              <a
+                href={plugin.cta.href}
+                data-umami-event={`Docs - ${plugin.name} GitHub`}
+              >
                 <svg
                   role="img"
                   class="icon--github"

--- a/src/components/pages/TopNav.astro
+++ b/src/components/pages/TopNav.astro
@@ -24,7 +24,7 @@ const isToolsActive = toolsSubmenu.some((menuItem) => {
 
 <header>
   <nav class="site-nav contentWrapper collapsed" id="siteNav">
-    <a href={homePageUrl} class="site-title">
+    <a href={homePageUrl} class="site-title" data-umami-event="Nav - Home">
       <img
         src={wmLogo.src}
         alt="Web Monetization logo"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,7 +37,7 @@ const t = useTranslations(lang)
           Web Monetization connects publishers, creators and their audiences,
           turning engagement into revenue. No friction, no barriers, no limits.
         </p>
-        <a class="btn primary flexible hero-btn" href="#start"
+        <a class="btn primary flexible hero-btn" href="#start" data-umami-event="Home page link - Get started today"
           >Get started today</a
         >
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,7 +37,10 @@ const t = useTranslations(lang)
           Web Monetization connects publishers, creators and their audiences,
           turning engagement into revenue. No friction, no barriers, no limits.
         </p>
-        <a class="btn primary flexible hero-btn" href="#start" data-umami-event="Home page link - Get started today"
+        <a
+          class="btn primary flexible hero-btn"
+          href="#start"
+          data-umami-event="Home page link - Get started today"
           >Get started today</a
         >
       </div>


### PR DESCRIPTION
I noticed we were missing analytics attributes for a few links in the WM site.