### PR TITLE
fix(spec): remove Uphold reference

### DIFF
--- a/specification/index.html
+++ b/specification/index.html
@@ -845,10 +845,10 @@
         or start monetization of a particular site if they wish to do so).
       </p>
       <p>
-        As [=payment pointers=] are generally provided as a service (e.g.,
-        Uphold), a <abbr title="Cross Site Scripting">XSS</abbr> attack could
-        inject malicious [=payment pointers=] into a page that uses the same
-        service. To mitigate such an attack, it is RECOMMENDED that developers:
+        As [=payment pointers=] are generally provided as a service, a
+        <abbr title="Cross Site Scripting">XSS</abbr> attack could inject
+        malicious [=payment pointers=] into a page that uses the same service.
+        To mitigate such an attack, it is RECOMMENDED that developers:
       </p>
       <ul>
         <li>host a [=payment pointer=] on their own servers and proxy


### PR DESCRIPTION
This removes the reference to Uphold, as it does not provide wallet addresses anymore.