### PR TITLE
docs(README): update community call info 

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,17 +159,15 @@ After a translation is provided, it must be reviewed by an additional contributo
 
 After a PR is submitted, it will be reviewed by a member of the Web Incubator Community Group (WICG). Ensure you're able to receive GitHub notifications so you'll know when the PR is approved and can be merged or if updates are required before approval is given.
 
-## Web Monetization Catchup Call
+## Web Monetization Community Call
 
-Our catchup calls are open to our community. We have them every other Thursday at 14:00 GMT, via Google Meet.
+Our catch-up calls are open to our community. We have them every fourth Thursday at 14:00 GMT, via Google Meet.
 
 To join the video meeting, click this link: https://meet.google.com/fjy-vjef-ogj
 Otherwise, to join by phone, dial +49 30 300195060 and enter this PIN: 982 511 322 1488#
 To view more phone numbers, click this link: https://tel.meet/fjy-vjef-ogj?hs=5
 
 Video call link: https://meet.google.com/fjy-vjef-ogj
-
-Or dial: (DE) 49 30 300195060 and enter this PIN: 982 511 322 1488#
 
 More phone numbers: https://tel.meet/fjy-vjef-ogj?hs=5
 


### PR DESCRIPTION
Changed from catch-up call to community call and took out DE-specific phone number.