### PR TITLE
fix: replaced Slack link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,4 +106,4 @@ If you are submitting on behalf of someone else and didn't contribute directly, 
 - Please respond to feedback promptly and make any necessary changes
 - Once approved, your changes will be merged into the main branch
 
-Thank you for contributing to Web Monetization! Join the conversation on [Slack](https://communityinviter.com/apps/interledger/interledger-working-groups-slack) to connect with other contributors and stay up to date on developments.
+Thank you for contributing to Web Monetization! Join the conversation on [Slack](https://join.slack.com/t/interledger/shared_invite/zt-44g089zrn-XdSIiHF~cs8Oo_MBmSfECA) to connect with other contributors and stay up to date on developments.

--- a/src/components/pages/Footer.astro
+++ b/src/components/pages/Footer.astro
@@ -116,7 +116,7 @@ const t = useTranslations(lang)
         </li>
         <li>
           <a
-            href="https://communityinviter.com/apps/interledger/interledger-working-groups-slack"
+            href="https://join.slack.com/t/interledger/shared_invite/zt-44g089zrn-XdSIiHF~cs8Oo_MBmSfECA"
             aria-label="Slack"
             data-umami-event="Footer - Slack"
             rel="noopener noreferrer"

--- a/src/content/docs/resources/get-involved.mdx
+++ b/src/content/docs/resources/get-involved.mdx
@@ -73,7 +73,7 @@ Before claiming an issue, ensure you have:
 
 Stuck on something? We're here to help:
 
-- Ask questions in the `#webmonetization` <LinkOut href='https://join.slack.com/t/interledger/shared_invite/zt-44g089zrn-XdSIiHF~cs8Oo_MBmSfECA'>Slack channel</LinkOut> for quick assistance
+- Ask questions in the `#webmonetization` <LinkOut href="https://join.slack.com/t/interledger/shared_invite/zt-44g089zrn-XdSIiHF~cs8Oo_MBmSfECA">Slack channel</LinkOut> for quick assistance
 - Start a <LinkOut href='https://github.com/WICG/webmonetization/discussions'>discussion</LinkOut> on GitHub for broader topics
 - Join our <LinkOut href='https://calendar.google.com/calendar/u/0/r/eventedit/copy/c2dyMjY4M2k1dXRrcjZkYW05Mmo3c2xzZm1fMjAyNTA3MTdUMTMwMDAwWiBtb2hhbW1lZEBpbnRlcmxlZGdlci5vcmc/bW9oYW1tZWRAaW50ZXJsZWRnZXIub3Jn?scp=ALL'>community calls</LinkOut>
 

--- a/src/content/docs/resources/get-involved.mdx
+++ b/src/content/docs/resources/get-involved.mdx
@@ -12,7 +12,7 @@ Welcome to the Web Monetization community! Whether you're a seasoned developer, 
 
 - **Explore the project:** Browse the <LinkOut href='https://github.com/WICG/webmonetization'>Web Monetization repository</LinkOut> to understand the specification structure and recent activity
 - **Join our community:**
-  - Connect with us on <LinkOut href='https://join.slack.com/t/interledger/shared_invite/zt-44g089zrn-XdSIiHF~cs8Oo_MBmSfECA`</LinkOut> in the `#webmonetization` channel for real-time discussions
+  - Connect with us on <LinkOut href='https://join.slack.com/t/interledger/shared_invite/zt-44g089zrn-XdSIiHF~cs8Oo_MBmSfECA'>`interledger.slack.com`</LinkOut> in the `#webmonetization` channel for real-time discussions
   - Join our <LinkOut href='https://calendar.google.com/calendar/u/0/r/eventedit/copy/c2dyMjY4M2k1dXRrcjZkYW05Mmo3c2xzZm1fMjAyNTA3MTdUMTMwMDAwWiBtb2hhbW1lZEBpbnRlcmxlZGdlci5vcmc/bW9oYW1tZWRAaW50ZXJsZWRnZXIub3Jn?scp=ALL'>Web Monetization Community calls</LinkOut>
   - Begin a <LinkOut href='https://github.com/WICG/webmonetization/discussions'>new discussion or contribute to existing discussions</LinkOut> in the WICG Web Monetization GitHub repo
   - <LinkOut href="https://github.com/WICG/webmonetization/issues">
@@ -73,7 +73,7 @@ Before claiming an issue, ensure you have:
 
 Stuck on something? We're here to help:
 
-- Ask questions in the `#webmonetization` <LinkOut href="https://join.slack.com/t/interledger/shared_invite/zt-44g089zrn-XdSIiHF~cs8Oo_MBmSfECA">Slack channel</LinkOut> for quick assistance
+- Ask questions in the `#webmonetization` <LinkOut href='https://join.slack.com/t/interledger/shared_invite/zt-44g089zrn-XdSIiHF~cs8Oo_MBmSfECA'>Slack channel</LinkOut> for quick assistance
 - Start a <LinkOut href='https://github.com/WICG/webmonetization/discussions'>discussion</LinkOut> on GitHub for broader topics
 - Join our <LinkOut href='https://calendar.google.com/calendar/u/0/r/eventedit/copy/c2dyMjY4M2k1dXRrcjZkYW05Mmo3c2xzZm1fMjAyNTA3MTdUMTMwMDAwWiBtb2hhbW1lZEBpbnRlcmxlZGdlci5vcmc/bW9oYW1tZWRAaW50ZXJsZWRnZXIub3Jn?scp=ALL'>community calls</LinkOut>
 

--- a/src/content/docs/resources/get-involved.mdx
+++ b/src/content/docs/resources/get-involved.mdx
@@ -12,7 +12,7 @@ Welcome to the Web Monetization community! Whether you're a seasoned developer, 
 
 - **Explore the project:** Browse the <LinkOut href='https://github.com/WICG/webmonetization'>Web Monetization repository</LinkOut> to understand the specification structure and recent activity
 - **Join our community:**
-  - Connect with us on <LinkOut href='https://communityinviter.com/apps/interledger/interledger-working-groups-slack'>`interledger.slack.com`</LinkOut> in the `#webmonetization` channel for real-time discussions
+  - Connect with us on <LinkOut href='https://join.slack.com/t/interledger/shared_invite/zt-44g089zrn-XdSIiHF~cs8Oo_MBmSfECA`</LinkOut> in the `#webmonetization` channel for real-time discussions
   - Join our <LinkOut href='https://calendar.google.com/calendar/u/0/r/eventedit/copy/c2dyMjY4M2k1dXRrcjZkYW05Mmo3c2xzZm1fMjAyNTA3MTdUMTMwMDAwWiBtb2hhbW1lZEBpbnRlcmxlZGdlci5vcmc/bW9oYW1tZWRAaW50ZXJsZWRnZXIub3Jn?scp=ALL'>Web Monetization Community calls</LinkOut>
   - Begin a <LinkOut href='https://github.com/WICG/webmonetization/discussions'>new discussion or contribute to existing discussions</LinkOut> in the WICG Web Monetization GitHub repo
   - <LinkOut href="https://github.com/WICG/webmonetization/issues">
@@ -73,7 +73,7 @@ Before claiming an issue, ensure you have:
 
 Stuck on something? We're here to help:
 
-- Ask questions in the `#webmonetization` <LinkOut href='https://communityinviter.com/apps/interledger/interledger-working-groups-slack'>Slack channel</LinkOut> for quick assistance
+- Ask questions in the `#webmonetization` <LinkOut href='https://join.slack.com/t/interledger/shared_invite/zt-44g089zrn-XdSIiHF~cs8Oo_MBmSfECA'>Slack channel</LinkOut> for quick assistance
 - Start a <LinkOut href='https://github.com/WICG/webmonetization/discussions'>discussion</LinkOut> on GitHub for broader topics
 - Join our <LinkOut href='https://calendar.google.com/calendar/u/0/r/eventedit/copy/c2dyMjY4M2k1dXRrcjZkYW05Mmo3c2xzZm1fMjAyNTA3MTdUMTMwMDAwWiBtb2hhbW1lZEBpbnRlcmxlZGdlci5vcmc/bW9oYW1tZWRAaW50ZXJsZWRnZXIub3Jn?scp=ALL'>community calls</LinkOut>
 


### PR DESCRIPTION
Community inviter link is no longer working so we're updating it with a  temporary replacement link.
Fixes #682 