### PR TITLE
chore(spec/flows): remove unused Extension biblio entry

### DIFF
--- a/specification/flows/index.html
+++ b/specification/flows/index.html
@@ -74,10 +74,6 @@
           title: "GNAP",
           href: "https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol",
         },
-        Extension: {
-          title: "Web Monetization Extension",
-          href: "https://github.com/interledger/web-monetization-extension"
-        },
         WebMonetization: {
           title: "Web Monetization",
           href: "https://webmonetization.org/specification/"


### PR DESCRIPTION
This removes the unused `Extension` entry from `localBiblio`.