### PR TITLE
feat(spec): add `onmonetization` IDL spec

### DIFF
--- a/specification/index.html
+++ b/specification/index.html
@@ -503,46 +503,65 @@
     </section>
     <section>
       <h2>
-        `onmonetization` event handler
+        Events
       </h2>
-      <p>
-        The `onmonetization` event handler is an [=event handler content
-        attribute=] that can be applied to any [=element=]. The user agent uses
-        it to notify that some [^link^] has been [=monetized=].
-      </p>
-    </section>
-    <section id="events">
-      <h2>
-        monetization event
-      </h2>
-      <p>
-        When the [=payment session=] has sent a |payment| with a non-zero
-        amount, perform the following steps:
-      </p>
-      <ol class="algorithm">
-        <li>Let |target:HTMLLinkElement| be the {{HTMLLinkElement}} associated
-        with the [=payment session=].
-        </li>
-        <li>If |target| is `null`, then return.
-        </li>
-        <li>Let |eventInitDict:MonetizationEventInit| be a
-        {{MonetizationEventInit}} dictionary, whose members are initialized to
-        match |payment|'s details.
-        </li>
-        <li>Let |event:MonetizationEvent| be a newly constructed
-        {{MonetizationEvent}} initialized with |eventInitDict|.
-        </li>
-        <li>[=Queue a task=] on the [=monetization task source=] to perform the
-        following steps:
-          <ol>
-            <li>If |target| is not connected, return.
-            </li>
-            <li>[=Fire an event=] named `"monetization"` at |target|, with
-            {{Event/bubbles}} initialized to true.
-            </li>
-          </ol>
-        </li>
-      </ol>
+      <section data-dfn-for="GlobalEventHandlers">
+        <h3>
+          Extensions to `GlobalEventHandlers` interface
+        </h3>
+        <p>
+          The <code><dfn data-cite=
+          "html/webappapis.html#globaleventhandlers">GlobalEventHandlers</dfn></code>
+          interface is defined in [[HTML]].
+        </p>
+        <pre class="idl">
+          partial interface mixin GlobalEventHandlers {
+            attribute EventHandler onmonetization;
+          };
+        </pre>
+        <dl>
+          <dt>
+            <dfn>onmonetization</dfn>
+          </dt>
+          <dd>
+            <p>
+              The attribute must be an [=event handler IDL attribute=] and [=event handler content attribute=] for
+              the {{monetization}} event supported by all [=element=]s, {{Document}} objects, and {{Window}} objects. The user agent
+          uses it to notify that some [^link^] has been [=monetized=].
+            </p>
+          </dd>
+        </dl>
+      </section>
+      <section id="events">
+        <h3>
+          <code><dfn data-dfn-type="event">monetization</dfn></code> event
+        </h3>
+        <p>
+          When the [=payment session=] has sent a |payment| with a non-zero
+          amount, perform the following steps:
+        </p>
+        <ol class="algorithm">
+          <li>Let |target:HTMLLinkElement| be the {{HTMLLinkElement}}
+          associated with the [=payment session=].
+          </li>
+          <li>If |target| is `null`, then return.
+          </li>
+          <li>Let |eventInitDict:MonetizationEventInit| be a
+          {{MonetizationEventInit}} dictionary, whose members are initialized
+          to match |payment|'s details.
+          </li>
+          <li>[=Queue a task=] on the [=monetization task source=] to perform
+          the following steps:
+            <ol>
+              <li>If |target| is not connected, return.
+              </li>
+              <li>[=Fire an event=] named `"monetization"` that uses the {{MonetizationEvent}} interface at |target|, with
+              its attributes initialized with |eventInitDict|, and {{Event/bubbles}} initialized to true.
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
     </section>
     <section>
       <h2>

--- a/specification/index.html
+++ b/specification/index.html
@@ -510,9 +510,7 @@
           Extensions to `GlobalEventHandlers` interface
         </h3>
         <p>
-          The <code><dfn data-cite=
-          "html/webappapis.html#globaleventhandlers">GlobalEventHandlers</dfn></code>
-          interface is defined in [[HTML]].
+          The {{GlobalEventHandlers}} interface is defined in [[HTML]].
         </p>
         <pre class="idl">
           partial interface mixin GlobalEventHandlers {
@@ -525,9 +523,11 @@
           </dt>
           <dd>
             <p>
-              The attribute must be an [=event handler IDL attribute=] and [=event handler content attribute=] for
-              the {{monetization}} event supported by all [=element=]s, {{Document}} objects, and {{Window}} objects. The user agent
-          uses it to notify that some [^link^] has been [=monetized=].
+              The attribute must be an [=event handler IDL attribute=] and
+              [=event handler content attribute=] for the {{monetization}}
+              event supported by all [=element=]s, {{Document}} objects, and
+              {{Window}} objects. The user agent uses it to notify that some
+              [^link^] has been [=monetized=].
             </p>
           </dd>
         </dl>
@@ -555,8 +555,10 @@
             <ol>
               <li>If |target| is not connected, return.
               </li>
-              <li>[=Fire an event=] named `"monetization"` that uses the {{MonetizationEvent}} interface at |target|, with
-              its attributes initialized with |eventInitDict|, and {{Event/bubbles}} initialized to true.
+              <li>[=Fire an event=] named `"monetization"` that uses the
+              {{MonetizationEvent}} interface at |target|, with its attributes
+              initialized with |eventInitDict|, and {{Event/bubbles}}
+              initialized to true.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
Closes #696.

This PR introduces the `onmonetization` IDL specification as currently it is only defined in prose. It also aligns the specification's event model with how Web Monetization is actually implemented and used in practice, as before it was not defined for any `Document` or `Window`.

And finally, I have reworded the event firing specification to better define the event to be used, as before it could be understood that `event` is not used.