### PR TITLE
chore(ci): granular GitHub workflow permissions and use env variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -2,6 +2,9 @@ name: Update contributors listing
 on: workflow_dispatch
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   get-contributors:
     runs-on: ubuntu-latest
@@ -19,16 +22,18 @@ jobs:
 
       - run: npm install @octokit/action
       - run: node .github/actions/get-contributors.cjs
-      - run: |
+      - env:
+          REPO: ${{ github.repository }}
+        run: |
           git config --global user.email "no-reply@github.com"
           git config --global user.name "GitHub Actions"
-          git branch bot/update-contributors-${{ env.NOW }}
-          git checkout bot/update-contributors-${{ env.NOW }}
+          git branch "bot/update-contributors-$NOW"
+          git checkout "bot/update-contributors-$NOW"
           git add src/data/contributors.json
           git commit -m "Update contributors.json"
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git push --set-upstream origin bot/update-contributors-${{ env.NOW }}
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}"
+          git push --set-upstream origin "bot/update-contributors-$NOW"
 
       - name: Create pull request
         run: |
-          gh pr create -B main -H bot/update-contributors-${{ env.NOW }} --title 'chore: update contributors data' --body 'This PR updates the contributors.json file used to display contributors on the home page.'
+          gh pr create -B main -H "bot/update-contributors-$NOW" --title 'chore: update contributors data' --body 'This PR updates the contributors.json file used to display contributors on the home page.'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -7,6 +7,9 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+permissions:
+  contents: read
+
 jobs:
   test-deploy:
     name: Test deployment


### PR DESCRIPTION
Adds an explicit least-privilege `permissions:` block to the workflows that previously had none. Each is scoped to only what its steps actually use.

Routes `${{ }}` values through `env` instead of interpolating them directly.