### PR TITLE
fix(docs): Adjust card colors in dark mode

### DIFF
--- a/src/components/docs/CustomCard.astro
+++ b/src/components/docs/CustomCard.astro
@@ -30,8 +30,12 @@ const { title, iconName, iconColor } = Astro.props
     /* Adds space below the card so it doesn't glue to content beneath it */
     margin-bottom: 1rem;
 
-    /* Optional: Adds a subtle background color if you want a boxed container look */
     background-color: #fcfcfc;
+  }
+
+  html[data-theme='dark'] .card {
+    color: #fff;
+    background-color: #171d4f;
   }
 
   /* Keeps the title layout clean and on one line */


### PR DESCRIPTION
Currently the announcement card on https://webmonetization.org/docs/ and https://webmonetization.org/resources/get-involved/ is too bright in dark mode and makes the links hard too see.

This adjusts the colors to use the same colors as the "note" on https://webmonetization.org/supporters/get-started/.