### PR TITLE
docs: add llms.txt support via starlight-llms-txt plugin

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import starlight from '@astrojs/starlight'
 import starlightLinksValidator from 'starlight-links-validator'
 import starlightFullViewMode from 'starlight-fullview-mode'
+import starlightLlmsTxt from 'starlight-llms-txt'
 
 // https://astro.build/config
 export default defineConfig({
@@ -37,6 +38,70 @@ export default defineConfig({
         starlightFullViewMode({
           leftSidebarEnabled: true,
           rightSidebarEnabled: true
+        }),
+        starlightLlmsTxt({
+          details: `Web Monetization documentation is for two audiences: web developers and publishers who want to add Web Monetization to a site, and supporters who install a browser extension to send payments while they browse. It is not the formal specification text itself — that is linked as an optional resource below.
+
+The Web Monetization tools for publishers, supporters, and developers are no longer being proactively developed by the Interledger Foundation in terms of new features or integrations — existing tools are maintained, open source, and available to use. The Web Monetization extension continues to exist as a wallet-agnostic browser extension. The project has moved to a community-led model for new feature contributions, reviewed by the Foundation. The Web Monetization standard itself continues to be actively stewarded by the Foundation.
+
+Key terminology notes:
+
+- A wallet address is the HTTPS URL identifying where a user's monetization-enabled digital wallet lives — not a cryptocurrency wallet, and formerly called a "payment pointer"
+- Publishers (or content owners) are the sites receiving payments; supporters are the people sending them via the browser extension
+- Continuous payments are the small, ongoing payment stream that runs while a monetized page is open, as opposed to a one-off checkout transaction
+- Probabilistic revenue share splits a payment stream across multiple wallet addresses (e.g. a creator and a platform) using randomized selection, not literal payment splitting
+- Web Monetization is a browser-facing API; it does not itself move payments between wallets. A Web Monetization-enabled wallet uses Open Payments (an API for authorizing and initiating payments between wallets) and the Interledger Protocol (ILP, the underlying routing protocol) to execute payments. This documentation does not cover the Open Payments API or ILP protocol internals — see the Open Payments and Interledger Protocol documentation for those`,
+          customSets: [
+            {
+              label: 'For content owners (publishers)',
+              paths: ['publishers/**'],
+              description:
+                'Guidance for publishers who want to receive Web Monetization payments, including the publisher tools (banner, offerwall, pay-per-article, widget, link tag generator, revenue share generator) and the WordPress plugin'
+            },
+            {
+              label: 'For content consumers (supporters)',
+              paths: ['supporters/**'],
+              description:
+                'Guidance for supporters who want to send Web Monetization payments by installing and using a browser extension'
+            },
+            {
+              label: 'Developers',
+              paths: ['developers/**'],
+              description:
+                'Reference documentation for integrating Web Monetization into a webpage, feed, or social profile: the monetization link element, wallet linking, the Web Monetization JS API, and relevant HTTP headers'
+            },
+            {
+              label: 'Guides and tutorials',
+              paths: ['guides/**', 'tutorials/**'],
+              description:
+                'Step-by-step guides for testing Web Monetization and tutorials for implementing common patterns, such as showing or hiding content for paying visitors and setting up probabilistic revenue sharing'
+            },
+            {
+              label: 'Resources',
+              paths: ['resources/**'],
+              description:
+                'Supporting reference material, including the Web Monetization glossary'
+            }
+          ],
+          optionalLinks: [
+            {
+              label: 'GitHub repository',
+              url: 'https://github.com/WICG/webmonetization',
+              description:
+                'Source code, issue tracker, and incubation discussion for the Web Monetization proposal'
+            },
+            {
+              label: 'Web Monetization specification',
+              url: 'https://webmonetization.org/specification/',
+              description: 'The formal Web Monetization specification document'
+            },
+            {
+              label: 'Open Payments documentation',
+              url: 'https://openpayments.dev',
+              description:
+                'Documentation for the Open Payments API that Web Monetization-enabled wallets use under the hood to execute payments'
+            }
+          ]
         })
       ],
       expressiveCode: {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -46,9 +46,11 @@ The Web Monetization tools for publishers, supporters, and developers are no lon
 
 Key terminology notes:
 
-- A wallet address is the HTTPS URL identifying where a user's monetization-enabled digital wallet lives — not a cryptocurrency wallet, and formerly called a "payment pointer"
+- A wallet address is the HTTPS URL identifying where a user's Web Monetization-enabled digital wallet lives — not a cryptocurrency wallet
+- A payment pointer is a separate identifier format some wallet providers still use, but it is not itself a wallet address — see the glossary for the format difference and how to convert a payment pointer to a wallet address
 - Publishers (or content owners) are the sites receiving payments; supporters are the people sending them via the browser extension
-- Continuous payments are the small, ongoing payment stream that runs while a monetized page is open, as opposed to a one-off checkout transaction
+- Continuous payments are the small, ongoing payment stream sent while a monetized page is the active, visible tab — not just open in the background
+- A one-time payment is a separate, single-payment mode that a supporter can send instead of, or in addition to, continuous payments
 - Probabilistic revenue share splits a payment stream across multiple wallet addresses (e.g. a creator and a platform) using randomized selection, not literal payment splitting
 - Web Monetization is a browser-facing API; it does not itself move payments between wallets. A Web Monetization-enabled wallet uses Open Payments (an API for authorizing and initiating payments between wallets) and the Interledger Protocol (ILP, the underlying routing protocol) to execute payments. This documentation does not cover the Open Payments API or ILP protocol internals — see the Open Payments and Interledger Protocol documentation for those`,
           customSets: [
@@ -74,7 +76,7 @@ Key terminology notes:
               label: 'Guides and tutorials',
               paths: ['guides/**', 'tutorials/**'],
               description:
-                'Step-by-step guides for testing Web Monetization and tutorials for implementing common patterns, such as showing or hiding content for paying visitors and setting up probabilistic revenue sharing'
+                'Step-by-step guides for testing Web Monetization using the Interledger test wallet (wallet.interledger-test.dev), and tutorials for implementing common patterns, such as showing or hiding content for paying visitors, displaying a contribution counter, and setting up probabilistic revenue sharing'
             },
             {
               label: 'Resources',
@@ -100,6 +102,12 @@ Key terminology notes:
               url: 'https://openpayments.dev',
               description:
                 'Documentation for the Open Payments API that Web Monetization-enabled wallets use under the hood to execute payments'
+            },
+            {
+              label: 'Interledger test wallet',
+              url: 'https://wallet.interledger-test.dev',
+              description:
+                'A test wallet from the Interledger Foundation for experimenting with sending and receiving Web Monetization payments without using real money'
             }
           ]
         })

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "sharp": "^0.34.5",
         "starlight-fullview-mode": "^0.2.6",
         "starlight-links-validator": "^0.24.0",
+        "starlight-llms-txt": "^0.9.0",
         "typescript": "^6.0.3"
       },
       "devDependencies": {
@@ -2335,6 +2336,12 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
+    "node_modules/@types/braces": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.5.tgz",
+      "integrity": "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -2661,6 +2668,15 @@
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
       "license": "MIT"
+    },
+    "node_modules/@types/micromatch": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.10.tgz",
+      "integrity": "sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/braces": "*"
+      }
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -3613,7 +3629,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -5582,7 +5597,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6129,6 +6143,32 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-mdast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-minify-whitespace": "^6.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
@@ -6546,7 +6586,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7958,7 +7997,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -7972,7 +8010,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -9011,6 +9048,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-minify-whitespace": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-parse": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
@@ -9050,6 +9101,23 @@
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
         "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "hast-util-to-mdast": "^10.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9815,6 +9883,30 @@
         "astro": ">=6.0.0"
       }
     },
+    "node_modules/starlight-llms-txt": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/starlight-llms-txt/-/starlight-llms-txt-0.9.0.tgz",
+      "integrity": "sha512-Yd/ZD0iR4U1tPkhW1O2dh1gBsMWueBni7Ht4hJVEUpoczwPy8U+Ii4OCVuYIQQYSI7crHyx60ZC+zYMqZM881Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/mdx": "^5.0.4",
+        "@types/hast": "^3.0.4",
+        "@types/micromatch": "^4.0.10",
+        "github-slugger": "^2.0.0",
+        "hast-util-select": "^6.0.4",
+        "micromatch": "^4.0.8",
+        "rehype-parse": "^9.0.1",
+        "rehype-remark": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-remove": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.38.0",
+        "astro": "^6.0.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -10109,7 +10201,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -10131,6 +10222,16 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trim-trailing-lines": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -10361,6 +10462,21 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-4.0.0.tgz",
+      "integrity": "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "sharp": "^0.34.5",
     "starlight-fullview-mode": "^0.2.6",
     "starlight-links-validator": "^0.24.0",
+    "starlight-llms-txt": "^0.9.0",
     "typescript": "^6.0.3"
   },
   "optionalDependencies": {

--- a/src/components/ExtensionLinks.astro
+++ b/src/components/ExtensionLinks.astro
@@ -28,8 +28,8 @@ const URLS = {
 
 const toURL = (url: string) => {
   const result = new URL(url)
-  if (utm && !utm.utm_source) {
-    result.searchParams.set('utm_source', Astro.site!.hostname)
+  if (utm && !utm.utm_source && Astro.site) {
+    result.searchParams.set('utm_source', Astro.site.hostname)
   }
   for (const [k, v] of Object.entries(utm || {})) {
     result.searchParams.set(k, v)


### PR DESCRIPTION
**Description of changes**
Installed `starlight-llms-txt` and configured for Web Monetization. The plugin generates three routes at build time:

- /llms.txt - curated index with project description and section links
- /llms-full.txt - complete documentation in a single flat file
- /llms-small.txt - condensed version with asides and whitespace collapsed

Special configuration for Web Monetization:

- `details` block explains the two main audiences (developers/publishers integrating WM vs. supporters sending payments), clarifies terminology that differs from common usage (wallet address vs. the older "payment pointer", continuous payments, probabilistic revenue share), notes how WM relates to Open Payments and ILP, and calls out the current maintenance status of the WM tools (community-led, no longer proactively developed for new features) so agents don't assume active feature development
- `customSets` groups content into five named subsets (For content owners (publishers), For content consumers (supporters), Developers, Guides and tutorials, Resources) - this helps agents pull targeted content instead of the whole file
- `optionalLinks` points to the GitHub repo, the Web Monetization specification, and the Open Payments documentation that WM-enabled wallets use under the hood to execute payments

Also required a small fix in ExtensionLinks.astro: Astro.site is undefined when `starlight-llms-txt` renders page content through Astro's container API (rather than a normal page request), which crashed /llms-full.txt and /llms-small.txt on any page embedding this component. Added a guard so the optional UTM param is only set when Astro.site is available — no change to normal page rendering.