### PR TITLE
docs: add docs freshness tracking and stale page automation

### DIFF
--- a/.github/scripts/check-stale-docs.sh
+++ b/.github/scripts/check-stale-docs.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+DOCS_DIR="src/content/docs"
+THRESHOLD_DAYS=180
+THRESHOLD=$(date -d "$THRESHOLD_DAYS days ago" +%s)
+
+echo "## Stale pages (not updated in $THRESHOLD_DAYS+ days)"
+echo ""
+
+found=0
+while IFS= read -r -d '' file; do
+  [[ "$file" == *"/es/"* ]] && continue
+  [[ "$file" == *"404"* ]] && continue
+
+  last_commit=$(git log -1 --format="%ct" -- "$file")
+  [[ -z "$last_commit" ]] && continue
+
+  if [[ "$last_commit" -lt "$THRESHOLD" ]]; then
+    last_date=$(git log -1 --format="%ci" -- "$file" | cut -c1-10)
+    days=$(( ($(date +%s) - last_commit) / 86400 ))
+    rel="${file#$DOCS_DIR/}"
+    echo "- $rel | Last updated: $last_date | ${days} days ago"
+    found=1
+  fi
+done < <(find "$DOCS_DIR" \( -name "*.mdx" -o -name "*.md" \) -print0)
+
+[[ $found -eq 0 ]] && echo "No stale pages found."
+exit 0

--- a/.github/workflows/stale-docs.yml
+++ b/.github/workflows/stale-docs.yml
@@ -1,0 +1,18 @@
+name: Stale docs check
+
+on:
+  schedule:
+    - cron: '0 9 1 * *'  # 9am on the 1st of every month
+  workflow_dispatch:      # allows manual trigger from the Actions tab
+
+jobs:
+  check-stale-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run stale docs check
+        run: bash .github/scripts/check-stale-docs.sh

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -132,6 +132,7 @@ Key terminology notes:
         PageTitle: './src/components/docs/PageTitle.astro',
         LastUpdated: './src/components/docs/LastUpdated.astro'
       },
+      lastUpdated: true,
       social: [
         {
           icon: 'github',

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -128,7 +128,9 @@ Key terminology notes:
       components: {
         Header: './src/components/docs/Header.astro',
         PageSidebar: './src/components/docs/PageSidebar.astro',
-        CustomCard: './src/components/docs/CustomCard.astro'
+        CustomCard: './src/components/docs/CustomCard.astro',
+        PageTitle: './src/components/docs/PageTitle.astro',
+        LastUpdated: './src/components/docs/LastUpdated.astro'
       },
       social: [
         {

--- a/src/components/docs/LastUpdated.astro
+++ b/src/components/docs/LastUpdated.astro
@@ -1,0 +1,3 @@
+---
+// Intentionally empty — lastUpdated date is rendered at the top of the page via the PageTitle component instead.
+---

--- a/src/components/docs/PageTitle.astro
+++ b/src/components/docs/PageTitle.astro
@@ -1,0 +1,34 @@
+---
+import Default from '@astrojs/starlight/components/PageTitle.astro'
+
+const { lastUpdated } = Astro.locals.starlightRoute || {}
+const locale = Astro.currentLocale || 'en'
+
+let formattedDate = null
+if (lastUpdated instanceof Date) {
+  formattedDate = lastUpdated.toLocaleDateString(
+    locale === 'es' ? 'es-ES' : 'en-US',
+    { year: 'numeric', month: 'short', day: 'numeric' }
+  )
+}
+
+const label = locale === 'es' ? 'Última revisión' : 'Last reviewed'
+---
+
+<Default {...Astro.props}><slot /></Default>
+{
+  formattedDate && (
+    <p class="last-updated-top">
+      {label}: {formattedDate}
+    </p>
+  )
+}
+
+<style>
+  .last-updated-top {
+    font-size: var(--sl-text-sm);
+    color: var(--sl-color-gray-3);
+    margin-top: -0.75rem;
+    margin-bottom: 1.5rem;
+  }
+</style>


### PR DESCRIPTION
Fixes DOC-107

Adds last reviewed date display and stale page detection to the Web Monetization docs site.

## Changes

- Enables `lastUpdated: true` in Starlight config to read dates from git history
- Adds custom `PageTitle` component to display "Last reviewed" date below each page title
- Adds empty `LastUpdated` component override to suppress the duplicate footer date
- Adds monthly stale docs check script and GitHub Actions workflow (runs 1st of each month, flags pages not updated in 180+ days)